### PR TITLE
Find teams UI update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "react-intersection-observer": "^9.5.2",
         "serve": "^14.2.0",
         "style-loader": "^3.3.3",
-        "typescript": "^4.9.5"
+        "typescript": "^4.9.5",
+        "webpack": "^5.89.0"
       },
       "engines": {
         "npm": ">=9.8.1 <10.0.0"
@@ -19079,9 +19080,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.88.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
-      "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "@acmucsd/acm-ai-site",
       "version": "2.0.0",
       "dependencies": {
+        "@dicebear/collection": "^7.0.1",
+        "@dicebear/core": "^7.0.1",
         "@types/aos": "^3.0.3",
         "@types/chart.js": "^2.9.27",
         "aos": "^3.0.0-beta.6",
@@ -2567,6 +2569,395 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@dicebear/adventurer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/adventurer/-/adventurer-7.0.1.tgz",
+      "integrity": "sha512-eqbHHAQO8HjG8YNMl8xgklxphC7HvfDtqVr1rkJWP98e7r2AdQpu0cPYIOZPV4uv9gxl1ncaErQjdjvIvFRGiA==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/adventurer-neutral": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/adventurer-neutral/-/adventurer-neutral-7.0.1.tgz",
+      "integrity": "sha512-dZfyaUFS8qQv7Lv+OXNTHVkercDCh+VqGSJU8jIf3FFbtFbFF79FXZJwJ8V3+pr0xKcZWa8i+8hXLtU3gqZ18g==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/avataaars": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/avataaars/-/avataaars-7.0.1.tgz",
+      "integrity": "sha512-U7JJLDFJsbVyQl3j1SqtTxi5h+I5JXL8CGfwAOPtQTnk/tKQFXM9WF/zdHegtxbxYAxQaYJtyprdwTJHx5ELnw==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/avataaars-neutral": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/avataaars-neutral/-/avataaars-neutral-7.0.1.tgz",
+      "integrity": "sha512-e3XwK3xup4ifJ/BUNjR5rcrw9982SC75UTJlPsKuuOM/Lwx3MtUe3+dqeDSyYbrC7KoWespX70oDZK1+2dBQFw==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-ears": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-ears/-/big-ears-7.0.1.tgz",
+      "integrity": "sha512-ITI0IQCwdn5s5/kUrNdO488TQvZdiCljnzKpqbQ1hqfsxZ0C+eZs+cudZ0bqLftYxM+WBvmaJwrh3pXNAz1h+w==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-ears-neutral": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-ears-neutral/-/big-ears-neutral-7.0.1.tgz",
+      "integrity": "sha512-2QK9HVmApoGFLi3ONW9mh0Tk/PPyHx9rvzUvcT5H/mb80ooBqIVMPYYq4rVlGVP6wAtsNHdoxzzlKja0DG+vvQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-smile": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-smile/-/big-smile-7.0.1.tgz",
+      "integrity": "sha512-hVAhUMZ0LUhMFvtmUDR8GU7v2ufl5pOcVPiVSC3oV8nyywFp7s1ZqYGhi6rBCEG3qsMR54JfMFWkjV88j4Yrmg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/bottts": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/bottts/-/bottts-7.0.1.tgz",
+      "integrity": "sha512-k0adSvnT9+gFDO7/Cmts9TM3CSWYrZrxZe1WpELjTvwe4QOqdn3LgrYR9JXU/2hRz3GaXtP02SHNd85CkadYVw==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/bottts-neutral": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/bottts-neutral/-/bottts-neutral-7.0.1.tgz",
+      "integrity": "sha512-1T1NEKAEvqyGlUprkO1Q1btITZnMBiCP5YeCy6wYyM7qJsPVDSySsjASJ1j/+IZFi8ePgWReFIbigFiHdo7iLA==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/collection": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/collection/-/collection-7.0.1.tgz",
+      "integrity": "sha512-Y5xzjU2hiklYUkqsSr5VBpVPG++iUUTm1UDJLPM+iXg3lMF3PQuifXoaAxcuoBvvnKfJKNHf5wP1Bq6nRUl4NA==",
+      "dependencies": {
+        "@dicebear/adventurer": "7.0.1",
+        "@dicebear/adventurer-neutral": "7.0.1",
+        "@dicebear/avataaars": "7.0.1",
+        "@dicebear/avataaars-neutral": "7.0.1",
+        "@dicebear/big-ears": "7.0.1",
+        "@dicebear/big-ears-neutral": "7.0.1",
+        "@dicebear/big-smile": "7.0.1",
+        "@dicebear/bottts": "7.0.1",
+        "@dicebear/bottts-neutral": "7.0.1",
+        "@dicebear/croodles": "7.0.1",
+        "@dicebear/croodles-neutral": "7.0.1",
+        "@dicebear/fun-emoji": "7.0.1",
+        "@dicebear/icons": "7.0.1",
+        "@dicebear/identicon": "7.0.1",
+        "@dicebear/initials": "7.0.1",
+        "@dicebear/lorelei": "7.0.1",
+        "@dicebear/lorelei-neutral": "7.0.1",
+        "@dicebear/micah": "7.0.1",
+        "@dicebear/miniavs": "7.0.1",
+        "@dicebear/notionists": "7.0.1",
+        "@dicebear/notionists-neutral": "7.0.1",
+        "@dicebear/open-peeps": "7.0.1",
+        "@dicebear/personas": "7.0.1",
+        "@dicebear/pixel-art": "7.0.1",
+        "@dicebear/pixel-art-neutral": "7.0.1",
+        "@dicebear/rings": "7.0.1",
+        "@dicebear/shapes": "7.0.1",
+        "@dicebear/thumbs": "7.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/converter": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/converter/-/converter-7.0.1.tgz",
+      "integrity": "sha512-CEIF6ZKi1FAE9kW10FvuPUjA6HLi+LcuB/GRFct/Bv28llzTel9xwbmfOEa1aIM8Nnp8BuT4U7tBIytksf+ptw==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11",
+        "tmp-promise": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@resvg/resvg-js": "^2.4.1",
+        "exiftool-vendored": "^22.0.0",
+        "sharp": "^0.32.1"
+      },
+      "peerDependenciesMeta": {
+        "@resvg/resvg-js": {
+          "optional": true
+        },
+        "exiftool-vendored": {
+          "optional": true
+        },
+        "sharp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@dicebear/core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/core/-/core-7.0.1.tgz",
+      "integrity": "sha512-jaJG693c+myLocgG3kKXdHa+WJ+S6OcD31SEr9Oby7hhOzALQYD+LcJ15oBWwI7SLHJcGPYTOLyx2eDr8YhXCQ==",
+      "dependencies": {
+        "@dicebear/converter": "7.0.1",
+        "@types/json-schema": "^7.0.11"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@dicebear/croodles": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/croodles/-/croodles-7.0.1.tgz",
+      "integrity": "sha512-uauBTUvKFvsiaT+LWYKCEboEeOJy2Pk055nsdczi13UgHHfj+Qvy0/ky/uzYn+WC/1gewqQ6w/yS1WfpgPtIpg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/croodles-neutral": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/croodles-neutral/-/croodles-neutral-7.0.1.tgz",
+      "integrity": "sha512-u09YylowZcbSAVyKJ4I8BCo1ehluqg3onYCclx++8mOWcEo+XGsGKIeN7osayaflNY/qtA9Jt2JsPgiS8KpQ5A==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/fun-emoji": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/fun-emoji/-/fun-emoji-7.0.1.tgz",
+      "integrity": "sha512-oJj5sb4rakro4e0lZTCkcKkiClHxDWr6+NWTwoU5L1HYRkXV6ngk4s7xSdOrYBQpYjLhdu+Lpx1VHYNpLUu2vg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/icons": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/icons/-/icons-7.0.1.tgz",
+      "integrity": "sha512-juHS4feScGCz4YdiwjxR60RJ2G7Z6W+tdUqNHN9ufMvY/FpJTfrQvzvrJfJfc84QZwIrqI/96WV3JIBEIO2AwQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/identicon": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/identicon/-/identicon-7.0.1.tgz",
+      "integrity": "sha512-9W9pqqhvpMsZmOkjuLwlw0iift56A3VFq7eNpJPB1mm6gytfqgxozgOVLDFgug9VXgUVI2Jrk/XnXGIFVIeVQA==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/initials": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/initials/-/initials-7.0.1.tgz",
+      "integrity": "sha512-zCI6fky4odM5ezl/GlhcSdnu+oNfmBbIghFB5NzgB/wV5nHmw2okONRC+Mgmxv8P8EpFb9z5hEOnh8xwW8htow==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/lorelei": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/lorelei/-/lorelei-7.0.1.tgz",
+      "integrity": "sha512-3pyI2JF70PlqZUZEs5pVxmQWDJ2/bWmGG/iFtwsEh9HivtF8Zon4Er0NrsEoiKDvScyY4VGwl4LyUBc8JvNb9w==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/lorelei-neutral": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/lorelei-neutral/-/lorelei-neutral-7.0.1.tgz",
+      "integrity": "sha512-4XaqE5v1dhE4TYrKSGG/VNUFqA31ADlqOnr6bd27E5MnaJLlY8ZAm3sue7EI9kEJ/i5KYov+Q4uS7JNDA5+cag==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/micah": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/micah/-/micah-7.0.1.tgz",
+      "integrity": "sha512-zHnEewRaREZGNTqnlZiSoha/wNFxEsVQ3E5QYpe9KB3rcLW4CVUgFAHjb449vniG6NfsAWzyAkOfhy4N6Zzw0g==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/miniavs": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/miniavs/-/miniavs-7.0.1.tgz",
+      "integrity": "sha512-v0n2JT0N1I7vAGoi4NQ98IKtn4JgjwD2Gkqq7l5QAy0jzl1v289FfTng0cOrthroMGBQ5jPS0wUyI0TluoFZRw==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/notionists": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/notionists/-/notionists-7.0.1.tgz",
+      "integrity": "sha512-uEYBywouoUmvWtWARyeqAoQWX1DpvKL33dVxZ5K/ulYd/nXu9WHeFCPaP4tqE5II1XPS4khwneimFN6F1HA5NQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/notionists-neutral": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/notionists-neutral/-/notionists-neutral-7.0.1.tgz",
+      "integrity": "sha512-jRA7u2UU1I9EXzqBZL3vwI/V7pdDT60yB3bBjyD5J4TznT7bMwt7qEm1eV31U37mn3H+LTFiPD9/4G6whiU3nQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/open-peeps": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/open-peeps/-/open-peeps-7.0.1.tgz",
+      "integrity": "sha512-z1gXzd7XXLzSZpOrDPZmnJDXySCUEKmunRdRuWBSRrfIcVkgStZM0y8uuSrs3LpR8U2xcNJN9yO2wNRRWKmFEw==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/personas": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/personas/-/personas-7.0.1.tgz",
+      "integrity": "sha512-6/nsrN7JIlMqdH7UwhrACVoCEM3IVHkpMq2I0A1JbhmYp240TI8kM5xYSF0KRdOyAPbyDH/TEB8Uld4LKE+3wQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/pixel-art": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/pixel-art/-/pixel-art-7.0.1.tgz",
+      "integrity": "sha512-9f17Ze4533CbHp23E+gRSSZdCUAB5/PieRq6/ZtVOnPI/PfglhhKMKSxQIm/H267gE2Y+VVhHpUTwGlbAgh1Lg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/pixel-art-neutral": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/pixel-art-neutral/-/pixel-art-neutral-7.0.1.tgz",
+      "integrity": "sha512-+9RS0ohGDbPu+W2eGGk3LyzvFbM5qsuhCQR4qO7YIcvmODyNFPJ7eW9g/MHFVPLQXq60SCEUF5CEKY0xs4baUQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/rings": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/rings/-/rings-7.0.1.tgz",
+      "integrity": "sha512-6wsLE4kbkBGeaaEA/afIV0eNYYfIVXo60XgApJA7JdcwyvdTa9LE5Wcp2VBEsZYXdsT9Ml7BC4er/QyMqCayUw==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/shapes": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/shapes/-/shapes-7.0.1.tgz",
+      "integrity": "sha512-/ol+SazDlJYYe5pYaqKcnYDBjux+2Ny57hIrkHhonV0z4ny3Pq6c4Lq+hN3MnTBpKJszCXLrSP3uCbSQpjnkOg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
+      }
+    },
+    "node_modules/@dicebear/thumbs": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@dicebear/thumbs/-/thumbs-7.0.1.tgz",
+      "integrity": "sha512-eQYVJ8NN9buPfbd2Va0fY8sHRq9n1d7FJt/dL9xwimRGlpWh9lqS6gcHazuSHhSgnRHsHLANEiyboIcyhWh2Hg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^7.0.0"
       }
     },
     "node_modules/@emotion/hash": {
@@ -18390,6 +18781,25 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "chart.js": "^2.9.4",
         "cors": "^2.8.5",
         "express": "^4.17.1",
+        "moment": "^2.30.1",
         "path-browserify": "^1.0.1",
         "postcss-loader": "^7.3.3",
         "prettier": "^2.1.2",
@@ -13211,9 +13212,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "chart.js": "^2.9.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "moment": "^2.30.1",
     "path-browserify": "^1.0.1",
     "postcss-loader": "^7.3.3",
     "prettier": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-intersection-observer": "^9.5.2",
     "serve": "^14.2.0",
     "style-loader": "^3.3.3",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "webpack": "^5.89.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "@acmucsd/acm-ai-site",
   "version": "2.0.0",
   "dependencies": {
+    "@dicebear/collection": "^7.0.1",
+    "@dicebear/core": "^7.0.1",
     "@types/aos": "^3.0.3",
     "@types/chart.js": "^2.9.27",
     "aos": "^3.0.0-beta.6",

--- a/src/actions/competition.ts
+++ b/src/actions/competition.ts
@@ -13,10 +13,8 @@ export type PastCompetition = {
 export interface CompetitionData {
     rank: number;
     team: string;
-    users: string[];
     score: number;
     submitHistory: Array<string>;
-    last: Date;
 }
 
 export const uploadSubmission = async (

--- a/src/actions/competition.ts
+++ b/src/actions/competition.ts
@@ -10,6 +10,15 @@ export type PastCompetition = {
   route: string;
 };
 
+export interface CompetitionData {
+    rank: number;
+    team: string;
+    users: string[];
+    score: number;
+    submitHistory: Array<string>;
+    last: Date;
+}
+
 export const uploadSubmission = async (
   file: File | undefined,
   tagsSelected: string[],

--- a/src/actions/teams/utils.ts
+++ b/src/actions/teams/utils.ts
@@ -142,7 +142,8 @@ export const addToTeam = async (
   let body = {
     username,
     teamName,
-    code,
+    competitionName,
+    code
   };
 
   return new Promise((resolve, reject) => {
@@ -155,7 +156,7 @@ export const addToTeam = async (
           headers: {
             Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
-          },
+          }
         }
       )
       .then((res: AxiosResponse) => {
@@ -168,3 +169,46 @@ export const addToTeam = async (
       });
   });
 };
+
+
+
+export const leaveTeam = async(
+  competitionName: string,
+  username: string,
+  teamName: string
+): Promise<AxiosResponse> => {
+  let token = getToken(COOKIE_NAME);
+
+  return new Promise((resolve, reject) => {
+    axios
+      .delete(
+        process.env.REACT_APP_API + 
+        `/v1/competitions/teams/${competitionName}/remove-member`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          data: {
+            username: username,
+            teamName: teamName,
+          }
+          
+
+        }
+       
+
+      )
+      .then((res: AxiosResponse) => {
+        resolve(res);
+      })
+      .catch((error) => {
+        message.error(error.response.data);
+        reject(error);
+      });
+  });
+
+
+
+};
+
+

--- a/src/components/TeamCard/index.less
+++ b/src/components/TeamCard/index.less
@@ -37,10 +37,11 @@ div.teamPreviewCard {
         font-weight: @semi-bold;
     }
 
-    span:first-of-type{
+    span:first-of-type {
         width: 70%;
         display: flex;
         align-items: center;
+
         p:nth-child(2){
             margin-left: 8px;
             display: inline;

--- a/src/components/TeamCard/index.less
+++ b/src/components/TeamCard/index.less
@@ -25,49 +25,61 @@ div.teamPreviewCard {
     width: 100%;
     display: grid;
     align-items: center;
-    grid-template-columns: 1.5fr 1fr 1fr;
+    grid-template-columns: 2fr 1fr 1fr;
     background: @gray;
     padding: @padding-base2;
     border-radius: @radius-base4;
     box-shadow: @bx3;
+    cursor: pointer;
 
 
-    h3 {
-        max-width: 300px;
-        font-weight: @semi-bold;
-    }
-
-    span:first-of-type {
-        width: 70%;
+  
+    span:first-child {
         display: flex;
         align-items: center;
-
-        p:nth-child(2){
-            margin-left: 8px;
-            display: inline;
-            background: rgb(33, 94, 247);
-            width: fit-content;
-            padding: 6px 20px;
-            border-radius: @radius-base6;
-            color: white;
+        h4 {
+            font-weight: @semi-bold;
         }
-        
     }
 
-    span:last-child {
-        width: 100%;
+    span:nth-of-type(2) {
+        display: flex;
+        align-items: center;
+        text-align: center;
+
+        p{
+            font-weight: @semi-bold;
+        }
+    }
+
+    span:last-of-type {
         display:flex;
         justify-content: end;
     }
 
+    @media screen and (max-width: 480px){
+        span#teamViewButtonSpan{
+            display: none;
+        }
 
+        span:nth-of-type(2) {
+            justify-content: end;
+        }
+    }
 }
+
+@media screen and (max-width: 480px){
+    div.teamPreviewCard {
+        grid-template-columns: 1fr 1fr;
+    }
+    
+}
+
+
 
 #teamViewButton {
     .button-black();
     width:fit-content;
-
-
 }
 
 

--- a/src/components/TeamCard/index.less
+++ b/src/components/TeamCard/index.less
@@ -23,10 +23,9 @@
 div.teamPreviewCard {
     
     width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+    display: grid;
     align-items: center;
+    grid-template-columns: 1fr 1fr 1fr;
     background: @gray;
     padding: @padding-base2;
     border-radius: @radius-base4;
@@ -38,10 +37,23 @@ div.teamPreviewCard {
         font-weight: @semi-bold;
     }
 
+    span:first-of-type{
+        text-align: center;
+    }
+
+    span:last-child {
+        width: 100%;
+        display:flex;
+        justify-content: end;
+    }
+
+
 }
 
 #teamViewButton {
     .button-black();
+    width:fit-content;
+
 
 }
 

--- a/src/components/TeamCard/index.less
+++ b/src/components/TeamCard/index.less
@@ -25,7 +25,7 @@ div.teamPreviewCard {
     width: 100%;
     display: grid;
     align-items: center;
-    grid-template-columns: 2fr 1fr 1fr;
+    grid-template-columns: 2fr 2fr;
     background: @gray;
     padding: @padding-base2;
     border-radius: @radius-base4;
@@ -57,29 +57,16 @@ div.teamPreviewCard {
         justify-content: end;
     }
 
-    @media screen and (max-width: 480px){
-        span#teamViewButtonSpan{
-            display: none;
-        }
-
-        span:nth-of-type(2) {
-            justify-content: end;
-        }
-    }
-}
-
-@media screen and (max-width: 480px){
-    div.teamPreviewCard {
-        grid-template-columns: 1fr 1fr;
-    }
-    
+   
 }
 
 
 
 #teamViewButton {
-    .button-black();
-    width:fit-content;
+    background-color: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 

--- a/src/components/TeamCard/index.less
+++ b/src/components/TeamCard/index.less
@@ -1,0 +1,51 @@
+@import '../../styles/base.less';
+@import '../../newStyles/variables.less';
+@import '../../newStyles/components.less';
+
+
+#teamModalContent {
+
+    section#teamMembersContainer {
+        background: @gray;
+        padding: @padding-base2;
+        border-radius: @radius-base4;
+        margin-top: 2rem;
+    }
+
+
+}
+
+#joinCodeInput {
+    max-width: 300px;
+    margin-right: 1rem;
+}
+
+div.teamPreviewCard {
+    
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    background: @gray;
+    padding: @padding-base2;
+    border-radius: @radius-base4;
+    box-shadow: @bx3;
+
+
+    h3 {
+        max-width: 300px;
+        font-weight: @semi-bold;
+    }
+
+}
+
+#teamViewButton {
+    .button-black();
+
+}
+
+
+#teamJoinButton {
+    .button-black-square();
+}

--- a/src/components/TeamCard/index.less
+++ b/src/components/TeamCard/index.less
@@ -25,7 +25,7 @@ div.teamPreviewCard {
     width: 100%;
     display: grid;
     align-items: center;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1.5fr 1fr 1fr;
     background: @gray;
     padding: @padding-base2;
     border-radius: @radius-base4;
@@ -38,7 +38,19 @@ div.teamPreviewCard {
     }
 
     span:first-of-type{
-        text-align: center;
+        width: 70%;
+        display: flex;
+        align-items: center;
+        p:nth-child(2){
+            margin-left: 8px;
+            display: inline;
+            background: rgb(33, 94, 247);
+            width: fit-content;
+            padding: 6px 20px;
+            border-radius: @radius-base6;
+            color: white;
+        }
+        
     }
 
     span:last-child {

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -2,7 +2,7 @@ import { Modal, Col, Button, Form, Input, message } from "antd";
 import { useState } from "react";
 import { User } from "../../UserContext";
 import { addToTeam, leaveTeam } from '../../actions/teams/utils';
-
+import './index.less';
 import React from "react";
 import { useForm } from "react-hook-form";
 import { error } from "console";
@@ -86,10 +86,21 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
                         )}
 
                         {!team.teamMembers.includes(user.username) && (
-                           
-                        <Button size= "large" type = "primary" loading = {confirmLoading} onClick = {onSubmit} >
-                            Join
-                        </Button>
+                            <>
+
+                                <Input
+                                    id = "joinCodeInput"
+                                    size = "large"
+                                    value={code}
+                                    onChange={(e) => setCode(e.target.value)}
+                                    placeholder="Code"
+                                />
+                             
+                            
+                                <Button id = "teamJoinButton" size= "large" type = "primary" loading = {confirmLoading} onClick = {onSubmit} >
+                                    Join
+                                </Button>
+                            </>
                         )}
 
                     </>    
@@ -97,36 +108,27 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
              >
                  <Col id = "teamModalContent">
  
-                     <section>
-                         <h4>Members</h4>
+                     <section id = "teamMembersContainer">
                          {team.teamMembers.map((member: string, index: number) => (
                              <p key={index}>{member}</p>
                          ))} 
                      </section>
 
-                     {!team.teamMembers.includes(user.username) && (
-
-                        <Input
-                            size = "large"
-                            value={code}
-                            onChange={(e) => setCode(e.target.value)}
-                            placeholder="Code"
-                        />
-                     )}
+        
                      
                  </Col>
              </Modal>
  
              {/* If user is in not in team, show option to join team */}
              <div id = {team.teamID} className = "teamPreviewCard">
-                 <h3><strong>{team.teamName}</strong></h3>
+                 <h3><b>{team.teamName}</b></h3>
                  <span>
                      <p>{team.teamMembers.length} members</p>
                      {team.teamMembers.includes(user.username) && (<p>your team</p>)}
                  </span>
          
                  {/** Clicking the button should open a modal to display team details and the option to join if user isn't part of team yet */}
-                 <Button size="large" shape="round" onClick={() => showModal()}>
+                 <Button id = "teamViewButton" size="large" shape="round" onClick={() => showModal()}>
                      <p>View</p>
                  </Button>
              </div>

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -121,7 +121,7 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
                  <h3><b>{team.teamName}</b></h3>
                  <span>
                      <p>{team.teamMembers.length} members</p>
-                     {team.teamMembers.includes(user.username) && (<p>your team</p>)}
+                     {team.teamMembers.includes(user.username) && (<p>you</p>)}
                  </span>
          
                  {/** Clicking the button should open a modal to display team details and the option to join if user isn't part of team yet */}

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -13,7 +13,10 @@ import { error } from "console";
 import { genColor } from "../../utils/colors";
 
 
-const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user:User, compUser: any, fetchTeamCallback: () => void })    => {
+const TeamCard = (
+    { team, user, compUser, fetchTeamCallback, updateRankings }: 
+    { team: any, user:User, compUser: any, fetchTeamCallback: () => void, updateRankings: () => void }
+)    => {
     // Modal state to trigger a team's details
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [code, setCode] = useState<string>("");
@@ -40,6 +43,9 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
 
             // trigger a refresh to refetch all the team data
             fetchTeamCallback();
+
+            // update the leaderboard with the new team
+            updateRankings();
           }
         )
         .catch((error) => {
@@ -55,13 +61,12 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
             setIsModalOpen(false);
 
             fetchTeamCallback();
+            updateRankings();
         })
         .catch((error) => (
             message.error(error)
         ));
     }
-
-
 
     // Modal props
     const showModal = () => {
@@ -144,7 +149,7 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
                  <span>
                     {/* <p>{team.teamMembers.length} members</p> */}
                     <Badge count = {team.teamMembers.length} color = "blue" style = {{outline: 'none'}} showZero>
-                        <Avatar style={{background: 'none'}}  shape = "square" icon = {<IoMdPerson id = "memberCountIcon" size={28} style={{color: 'grey'}}/>} />
+                        <Avatar style={{background: 'none'}}  shape = "square" icon = {<IoMdPerson id = "memberCountIcon" size={28} style={{color: 'lightgrey'}}/>} />
                     </Badge>
                  </span>
          

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -45,7 +45,7 @@ const TeamCard = (
             fetchTeamCallback();
 
             // update the leaderboard with the new team
-            updateRankings();
+            // updateRankings();
           }
         )
         .catch((error) => {
@@ -61,7 +61,7 @@ const TeamCard = (
             setIsModalOpen(false);
 
             fetchTeamCallback();
-            updateRankings();
+            // updateRankings();
         })
         .catch((error) => (
             message.error(error)

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -1,4 +1,4 @@
-import { Modal, Col, Button, Form, Input, message } from "antd";
+import { Modal, Col, Button, Form, Input, message, Badge } from "antd";
 import { useState } from "react";
 import { User } from "../../UserContext";
 import { addToTeam, leaveTeam } from '../../actions/teams/utils';
@@ -117,11 +117,11 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
              </Modal>
  
              {/* If user is in not in team, show option to join team */}
-             <div id = {team.teamID} className = "teamPreviewCard">
+             <div id = {team.teamID} className = "teamPreviewCard" style = {{ background: team.teamMembers.includes(user.username) ? '#F1F1F1': 'white'}}
+>
                  <h3><b>{team.teamName}</b></h3>
                  <span>
-                     <p>{team.teamMembers.length} members</p>
-                     {team.teamMembers.includes(user.username) && (<p>you</p>)}
+                    <p>{team.teamMembers.length} members</p>
                  </span>
          
                  {/** Clicking the button should open a modal to display team details and the option to join if user isn't part of team yet */}

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -113,9 +113,6 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
                              <p key={index}>{member}</p>
                          ))} 
                      </section>
-
-        
-                     
                  </Col>
              </Modal>
  
@@ -128,9 +125,12 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
                  </span>
          
                  {/** Clicking the button should open a modal to display team details and the option to join if user isn't part of team yet */}
-                 <Button id = "teamViewButton" size="large" shape="round" onClick={() => showModal()}>
-                     <p>View</p>
-                 </Button>
+                 <span>
+                    <Button id = "teamViewButton" size="large" shape="round" onClick={() => showModal()}>
+                        <p>View</p>
+                    </Button>
+                 </span>
+                 
              </div>
          </>
  

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -1,0 +1,138 @@
+import { Modal, Col, Button, Form, Input, message } from "antd";
+import { useState } from "react";
+import { User } from "../../UserContext";
+import { addToTeam, leaveTeam } from '../../actions/teams/utils';
+
+import React from "react";
+import { useForm } from "react-hook-form";
+import { error } from "console";
+
+
+const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user:User, compUser: any, fetchTeamCallback: () => void })    => {
+    // Modal state to trigger a team's details
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [code, setCode] = useState<string>("");
+    const [confirmLoading, setConfirmLoading] = useState(false);
+
+ 
+    const onSubmit = () => {
+        setConfirmLoading(true);
+
+        console.log("Comp user", compUser)
+        if(compUser.competitionTeam !== null) {
+            if(compUser.competitionTeam.teamName !== team.teamName) {
+                message.info("Cannot join another team if you're already in one")
+                setConfirmLoading(false);
+                return;
+            }
+        }
+
+        addToTeam(team.competitionName, user.username, team.teamName, code).then(
+          () => {
+            message.success('Joined team!');
+            setConfirmLoading(false);
+            setIsModalOpen(false);
+
+            // trigger a refresh to refetch all the team data
+            fetchTeamCallback();
+          }
+        )
+        .catch((error) => {
+            console.log(error);
+        });
+        setConfirmLoading(false);
+
+    };
+
+    const onLeaveTeam = () => {
+        leaveTeam(team.competitionName, user.username, team.teamName).then( (res) => {
+            message.success(res.data.msg);
+            setIsModalOpen(false);
+
+            fetchTeamCallback();
+        })
+        .catch((error) => (
+            message.error(error)
+        ));
+    }
+
+
+
+    // Modal props
+    const showModal = () => {
+        setIsModalOpen(true);
+    };
+    const handleCancel = () => {
+        setIsModalOpen(false);
+    };
+ 
+ 
+     return (
+         <>
+             <Modal
+                 className="teamDetailsModal"
+                 width={800}
+                 centered
+                 open={isModalOpen}
+                 onCancel={handleCancel}
+                 title={<h3 style={{ fontWeight: '700' }}>{team.teamName}</h3>}
+                 footer = {
+
+                    <>
+                        {team.teamMembers.includes(user.username) && (
+                            <Button  loading = {confirmLoading} size="large" shape="round" type="primary" onClick = {onLeaveTeam}>
+                                <p>leave</p>
+                            </Button>
+                        )}
+
+                        {!team.teamMembers.includes(user.username) && (
+                           
+                        <Button size= "large" type = "primary" loading = {confirmLoading} onClick = {onSubmit} >
+                            Join
+                        </Button>
+                        )}
+
+                    </>    
+                }
+             >
+                 <Col id = "teamModalContent">
+ 
+                     <section>
+                         <h4>Members</h4>
+                         {team.teamMembers.map((member: string, index: number) => (
+                             <p key={index}>{member}</p>
+                         ))} 
+                     </section>
+
+                     {!team.teamMembers.includes(user.username) && (
+
+                        <Input
+                            size = "large"
+                            value={code}
+                            onChange={(e) => setCode(e.target.value)}
+                            placeholder="Code"
+                        />
+                     )}
+                     
+                 </Col>
+             </Modal>
+ 
+             {/* If user is in not in team, show option to join team */}
+             <div id = {team.teamID} className = "teamPreviewCard">
+                 <h3><strong>{team.teamName}</strong></h3>
+                 <span>
+                     <p>{team.teamMembers.length} members</p>
+                     {team.teamMembers.includes(user.username) && (<p>your team</p>)}
+                 </span>
+         
+                 {/** Clicking the button should open a modal to display team details and the option to join if user isn't part of team yet */}
+                 <Button size="large" shape="round" onClick={() => showModal()}>
+                     <p>View</p>
+                 </Button>
+             </div>
+         </>
+ 
+     );
+ };
+ 
+ export default TeamCard;

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -1,11 +1,16 @@
-import { Modal, Col, Button, Form, Input, message, Badge } from "antd";
+import { Modal, Col, Button, Form, Input, message, Badge, Avatar } from "antd";
 import { useState } from "react";
 import { User } from "../../UserContext";
 import { addToTeam, leaveTeam } from '../../actions/teams/utils';
+import { BsPeopleFill } from "react-icons/bs";
+import { IoMdPerson } from "react-icons/io";
+
 import './index.less';
 import React from "react";
+
 import { useForm } from "react-hook-form";
 import { error } from "console";
+import { genColor } from "../../utils/colors";
 
 
 const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user:User, compUser: any, fetchTeamCallback: () => void })    => {
@@ -65,8 +70,10 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
     const handleCancel = () => {
         setIsModalOpen(false);
     };
- 
- 
+
+    const color1 = genColor(team.teamName);
+    const color2 = genColor(`${team.teamName}_additional_seed`);
+
      return (
          <>
              <Modal
@@ -95,42 +102,58 @@ const TeamCard = ({ team, user, compUser, fetchTeamCallback }: { team: any, user
                                     onChange={(e) => setCode(e.target.value)}
                                     placeholder="Code"
                                 />
-                             
-                            
                                 <Button id = "teamJoinButton" size= "large" type = "primary" loading = {confirmLoading} onClick = {onSubmit} >
                                     Join
                                 </Button>
                             </>
                         )}
-
                     </>    
                 }
              >
                  <Col id = "teamModalContent">
  
                      <section id = "teamMembersContainer">
-                         {team.teamMembers.map((member: string, index: number) => (
-                             <p key={index}>{member}</p>
-                         ))} 
+                        
+                        {team.teamMembers.length !== 0 ? 
+                            team.teamMembers.map((member: string, index: number) => (
+                                <p key={index}>{member}</p>
+                            ))
+                        
+                        : <p>no members</p>}          
                      </section>
                  </Col>
              </Modal>
  
              {/* If user is in not in team, show option to join team */}
-             <div id = {team.teamID} className = "teamPreviewCard" style = {{ background: team.teamMembers.includes(user.username) ? '#F1F1F1': 'white'}}
->
-                 <h3><b>{team.teamName}</b></h3>
+             <div id = {team.teamID} className = "teamPreviewCard" style = {{ background: team.teamMembers.includes(user.username) ? '#F1F1F1': 'white'}}  onClick={() => showModal()}>
                  <span>
-                    <p>{team.teamMembers.length} members</p>
+                    <div 
+                        style={{
+                            display: 'inline-flex',
+                            verticalAlign: 'middle',
+                            borderRadius: '100px',
+                            width: '32px',
+                            height:'32px',
+                            background: `linear-gradient(30deg, ${color1}, ${color2})`,
+                            marginRight: '1rem',
+                        }}>
+                    </div>
+                    <h4>{team.teamName}</h4>
+                 </span>
+
+                 <span>
+                    {/* <p>{team.teamMembers.length} members</p> */}
+                    <Badge count = {team.teamMembers.length} color = "blue" style = {{outline: 'none'}} showZero>
+                        <Avatar style={{background: 'none'}}  shape = "square" icon = {<IoMdPerson id = "memberCountIcon" size={28} style={{color: 'grey'}}/>} />
+                    </Badge>
                  </span>
          
                  {/** Clicking the button should open a modal to display team details and the option to join if user isn't part of team yet */}
-                 <span>
+                 <span id = "teamViewButtonSpan" >
                     <Button id = "teamViewButton" size="large" shape="round" onClick={() => showModal()}>
                         <p>View</p>
                     </Button>
                  </span>
-                 
              </div>
          </>
  

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { useForm } from "react-hook-form";
 import { error } from "console";
 import { genColor } from "../../utils/colors";
+import { FaEllipsisV } from "react-icons/fa";
 
 
 const TeamCard = (
@@ -130,34 +131,30 @@ const TeamCard = (
              </Modal>
  
              {/* If user is in not in team, show option to join team */}
-             <div id = {team.teamID} className = "teamPreviewCard" style = {{ background: team.teamMembers.includes(user.username) ? '#F1F1F1': 'white'}}  onClick={() => showModal()}>
+             <div id = {team.teamID} className = "teamPreviewCard" style = {{ background: team.teamMembers.includes(user.username) ? '#f0f0f0': 'white'}}  onClick={() => showModal()}>
                  <span>
                     <div 
                         style={{
                             display: 'inline-flex',
                             verticalAlign: 'middle',
                             borderRadius: '100px',
-                            width: '32px',
-                            height:'32px',
+                            width: '40px',
+                            height:'40px',
                             background: `linear-gradient(30deg, ${color1}, ${color2})`,
                             marginRight: '1rem',
                         }}>
                     </div>
-                    <h4>{team.teamName}</h4>
+
+                    <div>
+                        <h4>{team.teamName}</h4>
+                        <p style = {{color: "grey", fontSize: "14px"}}>{team.teamMembers.length} members</p>
+                    </div>
+                    
                  </span>
 
-                 <span>
-                    {/* <p>{team.teamMembers.length} members</p> */}
-                    <Badge count = {team.teamMembers.length} color = "blue" style = {{outline: 'none'}} showZero>
-                        <Avatar style={{background: 'none'}}  shape = "square" icon = {<IoMdPerson id = "memberCountIcon" size={28} style={{color: 'lightgrey'}}/>} />
-                    </Badge>
-                 </span>
-         
                  {/** Clicking the button should open a modal to display team details and the option to join if user isn't part of team yet */}
                  <span id = "teamViewButtonSpan" >
-                    <Button id = "teamViewButton" size="large" shape="round" onClick={() => showModal()}>
-                        <p>View</p>
-                    </Button>
+                    <Button type = "text" ghost id = "teamViewButton" onClick={() => showModal()}><p>view</p></Button>
                  </span>
              </div>
          </>

--- a/src/components/TeamCard/index.tsx
+++ b/src/components/TeamCard/index.tsx
@@ -57,7 +57,7 @@ const TeamCard = (
 
     const onLeaveTeam = () => {
         leaveTeam(team.competitionName, user.username, team.teamName).then( (res) => {
-            message.success(res.data.msg);
+            message.success('Successfully left team.');
             setIsModalOpen(false);
 
             fetchTeamCallback();

--- a/src/newStyles/components.less
+++ b/src/newStyles/components.less
@@ -47,6 +47,10 @@
     @media screen and (max-width: @sm){
         width: 100%;
     }
+
+    @media screen and (min-width: 769px){
+        width: 80%;
+    }
 }
 
 

--- a/src/newStyles/components.less
+++ b/src/newStyles/components.less
@@ -53,7 +53,6 @@
 // A wrapper for most sections with content 
 .generic-section {
     padding: 3rem @padding-base2;
-    margin: 0 auto; /* This will center the container horizontally */
     box-sizing: border-box; /* Include padding and borders within the width */
 }
 

--- a/src/newStyles/variables.less
+++ b/src/newStyles/variables.less
@@ -31,7 +31,7 @@
 @black: #282828;
 @white2: #f9fbff; // email background white
 @gray: #E9E9E9;
-@light-gray: #EfEfEf;
+@light-gray: #f0f0f0;
 @grayhover: #C9C9C9;
 @transparent-white-1: rgba(255,255,255,0.15);
 
@@ -51,7 +51,7 @@
 @blue: #42b0ff;
 @p1: #ff6f6f;
 @p2: #FF8D8B;
-@p3: #1260ba;
+@p3: rgb(18, 113, 255);
 @primary-color: #fe8019;
 
 @bg1: #001529;
@@ -99,7 +99,7 @@
 @xxs: 480px;
 @xs: 600px;
 @sm: 768px;
-@md: 992px;
+@md: 1000px;
 @lg: 1200px;
 
 

--- a/src/pages/Competitions/CompetitionLeaderboardPage/index.tsx
+++ b/src/pages/Competitions/CompetitionLeaderboardPage/index.tsx
@@ -2,34 +2,15 @@ import React, { useEffect, useRef, useState } from 'react';
 import './index.less';
 import { useHistory, useParams } from 'react-router-dom';
 import DefaultLayout from '../../../components/layouts/default';
-import { getMetaData, getLeaderboard } from '../../../actions/competition';
+import { getMetaData, getLeaderboard, CompetitionData } from '../../../actions/competition';
 import { Table, Button, Modal } from 'antd';
 import path from 'path';
 import ChartJS from 'chart.js';
 import { ColumnsType } from 'antd/lib/table';
 import { genColor } from '../../../utils/colors';
 
-interface CompetitionData {
-  rank: number;
-  team: string;
-  // users: string[];
-  score: number;
-  submitHistory: Array<string>;
-  // last: Date;
-}
 
-const stringHash = (str: string) => {
-  let hash = 0,
-    i,
-    chr;
-  if (str.length === 0) return hash;
-  for (i = 0; i < str.length; i++) {
-    chr = str.charCodeAt(i) * 2;
-    hash = (hash << 5) - hash + chr;
-    hash |= 0; // Convert to 32bit integer
-  }
-  return hash;
-};
+
 
 const columns: ColumnsType<CompetitionData> = [
   {
@@ -43,8 +24,8 @@ const columns: ColumnsType<CompetitionData> = [
     dataIndex: 'team',
     sorter: (a, b) => a.team.length - b.team.length,
     render(value, record, index) {
-      const color1 = genColor(value);
-      const color2 = genColor(`${value}_abcs`);
+      const color1 = genColor(record.team);
+      const color2 = genColor(`${record.team}_abcs`);
       return (
         <span>
           <div
@@ -70,13 +51,11 @@ const columns: ColumnsType<CompetitionData> = [
   {
     title: 'Score',
     dataIndex: 'score',
-    // defaultSortOrder: 'descend',
     sorter: (a, b) => a.score - b.score,
   },
   {
     title: 'Submissions',
     dataIndex: 'submitHistory',
-    // defaultSortOrder: 'descend',
     render: (v) => v.length,
     sorter: (a, b) => a.submitHistory.length - b.submitHistory.length,
   },
@@ -95,7 +74,6 @@ const CompetitionLeaderboardPage = () => {
     submissionsEnabled: boolean;
   } | null>(null);
   const [visible, setVisible] = useState(false);
-  const [chart, setChart] = useState<ChartJS | null>(null);
   const chartContainer = useRef<HTMLCanvasElement>(null);
   const [scoreHistTitle, setScoreHistTitle] = useState('');
   const params = useParams() as { id: string };
@@ -119,7 +97,6 @@ const CompetitionLeaderboardPage = () => {
       setData(newData);
     });
     getMetaData(competitionID).then((res) => {
-      // console.log("METADATA", res.data);
       setMeta(res.data);
     });
   };

--- a/src/pages/Competitions/CompetitionPortalPage/CountDownTimer.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/CountDownTimer.tsx
@@ -1,0 +1,70 @@
+
+import React, { useState, useEffect } from 'react';
+import moment from 'moment';
+
+const CountdownTimer = ({ endDate }: {endDate: any}) => {
+
+const calculateTimeRemaining = () => {
+    const now = moment();
+    const endDateTime = moment(endDate);
+    const duration = moment.duration(endDateTime.diff(now));
+
+    return {
+        days: duration.days(),
+        hours: duration.hours(),
+        minutes: duration.minutes(),
+        seconds: duration.seconds(),
+    };
+  };
+  const [timeRemaining, setTimeRemaining] = useState(calculateTimeRemaining());
+
+  
+  const formatTimeRemaining = () => {
+    const { days, hours, minutes, seconds } = timeRemaining;
+
+    if (days > 0) {
+      return `Closes in ${days} day${days !== 1 ? 's' : ''}${hours > 0 ? ` ${hours} hours` : ''}${
+        minutes > 0 ? ` ${minutes} minutes` : ''
+      }`;
+    } else if (hours > 0) {
+      return `Closes in ${hours} hour${hours !== 1 ? 's' : ''}${minutes > 0 ? ` ${minutes} minutes` : ''}`;
+    } else {
+      return `Closes in ${minutes} minute${minutes !== 1 ? 's' : ''}${seconds > 0 ? ` ${seconds} seconds` : ''}`;
+    }
+  };
+
+
+useEffect(() => {
+  let intervalId: string | number | NodeJS.Timeout | undefined;
+  
+  const updateInterval = () => {
+    const { minutes } = timeRemaining;
+    
+    if (minutes > 1) {
+      // Use a longer interval when there's more than 1 minute remaining
+      return 60 * 1000; // 1 minute
+    } else {
+      // Switch to a shorter interval when there's 1 minute or less remaining
+      return 1000; // 1 second
+    }
+  };
+
+  const updateTimer = () => {
+    setTimeRemaining(calculateTimeRemaining());
+  };
+
+  intervalId = setInterval(updateTimer, updateInterval());
+
+  return () => {
+    clearInterval(intervalId);
+  };
+}, [endDate]);
+
+
+
+  return (
+    <p>{formatTimeRemaining()}</p>
+  );
+};
+
+export default CountdownTimer;

--- a/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
@@ -127,7 +127,7 @@ const LineChart = ({ scoreHistory }: {scoreHistory: Array<number>}) => {
           <Statistic
               value={Math.abs(scoreHistoryPercentage)}
               precision={2}
-              valueStyle={{ color: scoreHistoryPercentage < 0 ? '#cf1322' : '#3f8600', fontSize: "1.2rem", display: "inline" }}
+              valueStyle={{ color: scoreHistoryPercentage < 0 ? '#cf1322' : '#3f8600', fontSize: "16px", display: "inline" }}
               prefix={scoreHistoryPercentage < 0 ? <ArrowDownOutlined /> : <ArrowUpOutlined />}
               suffix="%"
           />

--- a/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
@@ -73,23 +73,48 @@ const LineChart = ({ scoreHistory }: {scoreHistory: Array<number>}) => {
   const [chartTrigger, setTrigger] = useState(false);
 
   console.log(scoreHistory)
+
   useEffect(() => {
-    if (chartContainer && chartContainer.current && scoreHistory.length != 0) {
-      const myChartRef = chartContainer!.current!.getContext('2d');
-      const newchart = new ChartJS(myChartRef!, chartConfig);
-      setChart(newchart);
-      chartConfig.data.labels = [];
-      for (let i = 0; i < scoreHistory.length; i++) {
-        chartConfig.data.labels.push(i + 1);
+    if (chartContainer.current && scoreHistory.length !== 0) {
+      const myChartRef = chartContainer.current.getContext('2d');
+  
+      if (!chart) {
+        // Create the chart instance only once during the component mount
+        const newChart = new ChartJS(myChartRef!, chartConfig);
+        setChart(newChart);
       }
+  
+      // Update chart data and labels
+      chartConfig.data.labels = Array.from({ length: scoreHistory.length }, (_, i) => i + 1);
       chartConfig.data.datasets[0].data = scoreHistory;
+  
+      // Update the chart
       chart?.update();
     }
   }, [chartTrigger]);
+  // useEffect(() => {
+    
+  //   if (chartContainer && chartContainer.current && scoreHistory.length != 0) {
+     
+  //     const myChartRef = chartContainer!.current!.getContext('2d');
+      
+  //     const newchart = new ChartJS(myChartRef!, chartConfig);
+  //     setChart(newchart);
+      
+  //     chartConfig.data.labels = [];
+  //     for (let i = 0; i < scoreHistory.length; i++) {
+  //       chartConfig.data.labels.push(i + 1);
+  //     }
+      
+  //     chartConfig.data.datasets[0].data = scoreHistory;
+  //     chart?.update();
+  //   }
+  // }, [chartTrigger]);
 
-   // uses a second hook to address bug where chartContainer ref does not update in time nor triggers callback
+  //  // uses a second hook to address bug where chartContainer ref does not update in time nor triggers callback
    useEffect(() => {
     setTrigger(true);
+    
   }, [scoreHistory]);
 
 

--- a/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ChartJS from 'chart.js';
-import { Empty } from 'antd';
+import { Empty, Statistic } from 'antd';
+import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
 
 const chartConfig = {
   type: 'line',
@@ -71,10 +72,21 @@ const LineChart = ({ scoreHistory }: {scoreHistory: Array<number>}) => {
   const chartContainer = useRef<HTMLCanvasElement>(null);
   const [chart, setChart] = useState<ChartJS | null>(null);
   const [chartTrigger, setTrigger] = useState(false);
+  const [scoreHistoryPercentage, setScoreHistoryPercentage] = useState<number>(0);
 
   console.log(scoreHistory)
 
   useEffect(() => {
+    if(scoreHistory.length != 0) {
+
+        // Find relative growth of scores
+        let lastTwo = scoreHistory.slice(-2);
+        
+        const diff = lastTwo[1] - lastTwo[0];
+        const percent = diff / lastTwo[0];
+        setScoreHistoryPercentage(percent);
+    }
+    
     if (chartContainer.current && scoreHistory.length !== 0) {
       const myChartRef = chartContainer.current.getContext('2d');
   
@@ -92,24 +104,7 @@ const LineChart = ({ scoreHistory }: {scoreHistory: Array<number>}) => {
       chart?.update();
     }
   }, [chartTrigger]);
-  // useEffect(() => {
-    
-  //   if (chartContainer && chartContainer.current && scoreHistory.length != 0) {
-     
-  //     const myChartRef = chartContainer!.current!.getContext('2d');
-      
-  //     const newchart = new ChartJS(myChartRef!, chartConfig);
-  //     setChart(newchart);
-      
-  //     chartConfig.data.labels = [];
-  //     for (let i = 0; i < scoreHistory.length; i++) {
-  //       chartConfig.data.labels.push(i + 1);
-  //     }
-      
-  //     chartConfig.data.datasets[0].data = scoreHistory;
-  //     chart?.update();
-  //   }
-  // }, [chartTrigger]);
+
 
   //  // uses a second hook to address bug where chartContainer ref does not update in time nor triggers callback
    useEffect(() => {
@@ -123,14 +118,29 @@ const LineChart = ({ scoreHistory }: {scoreHistory: Array<number>}) => {
     {scoreHistory.length == 0 ? 
       <Empty />
       : 
-    /* WARNING: DO NOT remove the max height. ChartJS has a bug where changing the scorehistory
-     * causes the line graph to grow down infinitely. This can happen whenever the user leaves and 
-     * joins another team. 
-     */
-    <canvas style = {{ width: "100%", margin: "3rem 0", maxHeight: "400px"}} ref={chartContainer} />
-    }
+      /* WARNING: DO NOT remove the max height. ChartJS has a bug where changing the scorehistory
+      * causes the line graph to grow down infinitely. This can happen whenever the user leaves and 
+      * joins another team. 
+      */
+      <div>
+        {scoreHistoryPercentage ?
+          <Statistic
+              value={Math.abs(scoreHistoryPercentage)}
+              precision={2}
+              valueStyle={{ color: scoreHistoryPercentage < 0 ? '#cf1322' : '#3f8600', fontSize: "1.2rem", display: "inline" }}
+              prefix={scoreHistoryPercentage < 0 ? <ArrowDownOutlined /> : <ArrowUpOutlined />}
+              suffix="%"
+          />
+          :
+          <></>
+        }
+        <canvas style = {{ width: "100%", margin: "3rem 0", maxHeight: "400px"}} ref={chartContainer} />
+      </div>
+
+      }
     </>
-    )
+    
+  )
       
 };
 

--- a/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ChartJS from 'chart.js';
+import { Empty } from 'antd';
 
 const chartConfig = {
   type: 'line',
@@ -73,7 +74,7 @@ const LineChart = ({ scoreHistory }: {scoreHistory: Array<number>}) => {
 
   console.log(scoreHistory)
   useEffect(() => {
-    if (chartContainer && chartContainer.current) {
+    if (chartContainer && chartContainer.current && scoreHistory.length != 0) {
       const myChartRef = chartContainer!.current!.getContext('2d');
       const newchart = new ChartJS(myChartRef!, chartConfig);
       setChart(newchart);
@@ -89,11 +90,23 @@ const LineChart = ({ scoreHistory }: {scoreHistory: Array<number>}) => {
    // uses a second hook to address bug where chartContainer ref does not update in time nor triggers callback
    useEffect(() => {
     setTrigger(true);
-  }, []);
+  }, [scoreHistory]);
 
 
-  return <canvas style = {{ width: "100%", marginTop: "3rem", marginBottom: "1.5rem"}} ref={chartContainer} />;
-
+  return (
+    <>
+    {scoreHistory.length == 0 ? 
+      <Empty />
+      : 
+    /* WARNING: DO NOT remove the max height. ChartJS has a bug where changing the scorehistory
+     * causes the line graph to grow down infinitely. This can happen whenever the user leaves and 
+     * joins another team. 
+     */
+    <canvas style = {{ width: "100%", margin: "3rem 0", maxHeight: "400px"}} ref={chartContainer} />
+    }
+    </>
+    )
+      
 };
 
 

--- a/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/LineChart.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef, useState } from 'react';
+import ChartJS from 'chart.js';
+
+const chartConfig = {
+  type: 'line',
+  data: {
+    labels: [0],
+    datasets: [
+      {
+        data: [0],
+        pointBackgroundColor: 'rgb(18, 113, 255)',
+        backgroundColor: (ctx: any) => {
+          const canvas = ctx.chart.ctx;
+          const containerHeight = canvas.canvas.clientHeight; // Get the height of the container
+
+          const gradient = canvas.createLinearGradient(0, -160, 0, containerHeight);
+  
+          gradient.addColorStop(0, 'rgb(18, 113, 255)');
+          gradient.addColorStop(1, 'rgba(255, 255, 255, 0.6)');
+  
+          return gradient;
+        },
+        borderColor: 'rgb(18, 113, 255)',
+      },
+    ],
+  },
+  options: {
+    responsive: true,
+    title: {
+      display: false,
+    },
+    legend: {
+      display: false
+    },
+    elements: {
+      rectangle: {
+        backgroundColor: '', // Change this to the color you want for the entire chart background
+      },
+    },
+    scales: {
+      yAxes: [{
+        ticks: {
+          display: true,
+          fontColor: "grey"
+        },
+        gridLines: {
+          display: false
+        },
+    
+        angleLines: {
+          display: false
+        }
+      }],
+      xAxes: [{
+        ticks: {
+          display: true,
+          length: 0,
+          fontColor: "grey"
+        },
+       
+        angleLines: {
+          display: false
+        }
+      }],
+    },
+  },
+};
+
+const LineChart = ({ scoreHistory }: {scoreHistory: Array<number>}) => {
+  const chartContainer = useRef<HTMLCanvasElement>(null);
+  const [chart, setChart] = useState<ChartJS | null>(null);
+  const [chartTrigger, setTrigger] = useState(false);
+
+  console.log(scoreHistory)
+  useEffect(() => {
+    if (chartContainer && chartContainer.current) {
+      const myChartRef = chartContainer!.current!.getContext('2d');
+      const newchart = new ChartJS(myChartRef!, chartConfig);
+      setChart(newchart);
+      chartConfig.data.labels = [];
+      for (let i = 0; i < scoreHistory.length; i++) {
+        chartConfig.data.labels.push(i + 1);
+      }
+      chartConfig.data.datasets[0].data = scoreHistory;
+      chart?.update();
+    }
+  }, [chartTrigger]);
+
+   // uses a second hook to address bug where chartContainer ref does not update in time nor triggers callback
+   useEffect(() => {
+    setTrigger(true);
+  }, []);
+
+
+  return <canvas style = {{ width: "100%", marginTop: "3rem", marginBottom: "1.5rem"}} ref={chartContainer} />;
+
+};
+
+
+export default LineChart;

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -24,12 +24,9 @@
   #portalStatsContent {
     width: 100%;
     margin-top: 2rem;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
 
-    p#noTeamMessage {
-      margin-top: 2rem;
+
+    section#noTeamMessage {
       min-height: 100px;
       text-align: left;
       align-items: center;

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -251,10 +251,6 @@
 
   }
 
-
-
-
-
   div#sideContent {
     margin-top: 1rem;
     margin-left: 2rem;
@@ -302,8 +298,18 @@
         cursor: pointer;
       }
     }
+
+    div#matchesBox {
+      height: fit-content;
+      box-sizing: border-box;
+      padding: @padding-base3;
+      background-color: @light-gray;
+      border-radius: @radius-base4;
+      margin-top: 3rem;
+    }
   }
 }
+
 
 
 @media screen and (max-width: @lg) {

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -43,6 +43,7 @@
   #portalTabContent {
     .generic-section();
     .constrained-bounds();
+    height: 100vh;
     max-width: 1200px !important;
 
 
@@ -63,7 +64,6 @@
 }
 
 #myTeamContainer {
-  height: 100vh;
   #teamNameInput {
     max-width: 300px;
   }

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -43,6 +43,13 @@
     }
   }
 
+  #findTeamsContainer {
+    AutoComplete#teamSearchBar {
+      font-size: 1.2rem;
+      width: 100%;
+    } 
+  }
+
 
   .teamPreviewCard {
     width: 100%;

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -52,7 +52,9 @@
   }
 
   #findTeamsContainer {
-    AutoComplete#teamSearchBar {
+    height: 100vh;
+
+    #teamSearchBar {
       font-size: 1.2rem;
       width: 100%;
     } 
@@ -61,11 +63,19 @@
 }
 
 #myTeamContainer {
+  height: 100vh;
   #teamNameInput {
     max-width: 300px;
   }
 
   #makeTeamButton {
     margin-top: 1rem;
+  }
+
+  #teamAffix {
+    box-sizing: border-box;
+    box-shadow: @bx2;
+    border-radius: @radius-base4;
+    padding: @padding-base3;
   }
 }

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -234,6 +234,10 @@
     margin: 2rem auto;
   }
 
+  .submitButton {
+    margin-top: 1rem;
+  }
+
   #teamNameInput {
     max-width: 300px;
   }
@@ -297,6 +301,7 @@
   #teamHeader {
     display: flex;
     margin-bottom: 2rem;
+    align-items: center;
   }
 }
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -5,9 +5,9 @@
 
 .CompetitionPortalPage {
   .noContainer();
+  height: 100vh;
 
   // prevents layout shifts caused by scrollbar 
-  overflow-y: hidden;
   background: @white;
 
 
@@ -15,7 +15,6 @@
     .generic-section();
     .constrained-bounds();
     max-width: 1200px !important;
-
     margin-top: 4rem;
   }
 
@@ -23,7 +22,6 @@
 
 
   #portalStatsContent {
-
 
     p#noTeamMessage {
       margin-top: 2rem;
@@ -44,23 +42,38 @@
     .generic-section();
     .constrained-bounds();
     height: 100vh;
+
     max-width: 1200px !important;
-
-
     .ant-tabs-ink-bar {
       display: none;
     }
   }
 
-  #findTeamsContainer {
-    height: 100vh;
 
-    #teamSearchBar {
-      font-size: 1.2rem;
-      width: 100%;
-    } 
+  #findTeamsContainer {
+
+
+    Input {
+      line-height: 2.5rem ;
+      font-size: @font3;
+    }
   }
 
+}
+
+
+#leaderBoardContainer {
+
+  section {
+    display: inline-flex;
+    width: 100%;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+    
+    Button {
+      .button-black-square();
+    }
+  }
 }
 
 #myTeamContainer {
@@ -79,3 +92,4 @@
     padding: @padding-base3;
   }
 }
+

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -22,16 +22,54 @@
 
 
   #portalStatsContent {
+    width: 100%;
+    margin-top: 2rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
 
     p#noTeamMessage {
       margin-top: 2rem;
+      min-height: 100px;
       text-align: left;
+      align-items: center;
       background: @black;
       border-radius: @radius-base4;
-      padding: @padding-base3;
+      padding: @padding-base2;
       max-width: @sm;
       color: @white;
+    }
 
+    section {
+      display: inline-flex;
+    }
+    .portalStatsBox {
+      min-height: 100px;
+      width: 100%;
+      padding:  @padding-base2;
+      border-radius: @radius-base4;
+      display: flex;
+      flex-direction: column;
+
+      h3, p {
+        color: white;
+      }
+    }
+
+
+    .portalStatsBox:first-child {
+      background-color: @p3;
+    }
+
+    .portalStatsBox:not(:first-child) {
+      background-color: @light-gray;
+      h3, p {
+        color: black;
+      }
+    }
+
+    .portalStatsBox:not(:last-child) {
+      margin-right: 2rem;
     }
     
   }
@@ -69,6 +107,13 @@
     width: 100%;
     justify-content: space-between;
     margin-bottom: 1rem;
+
+    p#lastRefreshedText {
+      background: @light-gray;
+      border-radius: @radius-base4;
+      padding: @padding-base;
+      margin-right: 2rem;
+    }
 
     Button {
       .button-black-square();

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -64,51 +64,101 @@
       display: flex;
       flex-wrap: wrap;
       width: 100%;
-      justify-content: space-between;
-    }
+      padding: 0;
+  
 
-    .portalStatsBox {
-      background-color: white;
-      box-shadow: @bx3;
-      min-height: 140px;
-      padding: @padding-base2;
-      border-radius: @radius-base4;
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-      transition: background-color 0.2s ease-in;
-
-      flex: 1 0 20%;
-      min-width: 100px;
-      box-sizing: border-box;
-
-      span {
+      .portalStatsBox {
+        background-color: white;
+        box-shadow: @bx3;
+        min-height: 140px;
+        padding: @padding-base2;
+        border-radius: @radius-base4;
         display: flex;
-        justify-content: start;
-        flex-direction: row;
-        align-items: center;
-        flex-wrap: wrap;
+        flex-direction: column;
+        justify-content: space-between;
+        transition: background-color 0.2s ease-in;
 
-        p {
-          color: @text-gray3;
+        flex: 1 0 20%;
+        min-width: 124px;
+        box-sizing: border-box;
+
+        span {
+          display: flex;
+          justify-content: start;
+          flex-direction: row;
+          align-items: center;
+          flex-wrap: wrap;
+
+          p {
+            color: @text-gray3;
+          }
+
         }
 
+        p.stat {
+          font-size: 2.8rem;
+          font-weight: @semi-bold;
+          margin-top: 1rem;
+        }
       }
 
-      p.stat {
-        font-size: 2.8rem;
-        font-weight: @semi-bold;
-        margin-top: 1rem;
+      @media screen and (max-width: @md) {
+        .portalStatsBox {
+          flex: 1 0 45%;
+          margin-right: 0;
+          margin-bottom: 2rem;
+        }
+      }
+
+      .portalStatsBox:not(:last-child) {
+        margin-right: 2rem;
+      }
+
+      .portalStatsBox:last-child {
+        background: none;
+        box-shadow: none;
+        padding: 0;
+        margin-left: 2rem;
+
+        span {
+          display: inline-flex;
+          flex-direction: row;
+          margin-bottom: 1rem;
+
+          p {
+            font-weight: @semi-bold;
+            width: 100%;
+          }
+
+        }
+
+        #scoreHistoryChart {
+          display: flex;
+          flex-direction: row;
+          align-items: flex-end;
+
+          .scoreBar {
+            border-radius: @radius-base1;
+            background-color: @black;
+            width: 2rem;
+            transition: all 0.2s ease-in;
+            cursor: pointer;
+          }
+
+          .scoreBar:hover {
+            background-color: @mainred;
+          }
+
+
+          .scoreBar:not(:last-child) {
+            margin-right: 1rem;
+          }
+        }
       }
     }
+  }
 
 
-    @media screen and (max-width: @md) {
-      .portalStatsBox {
-        flex: 1 0 45%;
-        margin-bottom: 2rem;
-      }
-    }
 
 
     @media screen and (max-width: @lg) {
@@ -120,54 +170,6 @@
 
 
 
-    .portalStatsBox:not(:last-child) {
-      margin-right: 2rem;
-    }
-
-    .portalStatsBox:last-child {
-      background: none;
-      box-shadow: none;
-      padding: 0;
-      margin-left: 2rem;
-
-      span {
-        display: inline-flex;
-        flex-direction: row;
-        margin-bottom: 1rem;
-
-        p {
-          font-weight: @semi-bold;
-          width: 100%;
-        }
-
-      }
-
-      #scoreHistoryChart {
-        display: flex;
-        flex-direction: row;
-        align-items: flex-end;
-
-        .scoreBar {
-          border-radius: @radius-base1;
-          background-color: @black;
-          width: 2rem;
-          transition: all 0.2s ease-in;
-          cursor: pointer;
-        }
-
-        .scoreBar:hover {
-          background-color: @mainred;
-        }
-
-
-        .scoreBar:not(:last-child) {
-          margin-right: 1rem;
-        }
-      }
-    }
-
-
-  }
 
   #portalTabContent {
     .generic-section();

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -123,10 +123,10 @@
   #findTeamsContainer {
     margin-top: 1rem;
     margin-bottom: 5rem;
-
+    
     Input {
       line-height: 2.5rem;
-      font-size: @font3;
+      font-size: minmax(14px, 6rem);
     }
   }
 
@@ -200,12 +200,10 @@
       #rankingTag {
         border-radius: @radius-base5;
         background-color: rgb(18, 113, 255);
-        padding: 4px 12px;
+        padding: 4px 10px;
         width: fit-content;
-        font-size: 1.1rem;
         color: white;
         transform: translateY(4px);
-        box-sizing: border-box;
         font-weight: @semi-bold;
       }
     }

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -80,7 +80,6 @@
 
       flex: 1 0 20%;
       min-width: 100px;
-      /* Ensure items can shrink */
       box-sizing: border-box;
 
       span {
@@ -177,7 +176,8 @@
     max-width: 1200px !important;
 
     .ant-tabs-ink-bar {
-      display: none;
+      display: block;
+      background-color: @mainred;
     }
 
   
@@ -185,6 +185,8 @@
 
 
   #findTeamsContainer {
+    margin-top: 1rem;
+
     margin-bottom: 5rem;
 
     Input {
@@ -197,7 +199,7 @@
 
 
 #leaderBoardContainer {
-
+  margin-top: 1rem;
   section {
     display: inline-flex;
     width: 100%;
@@ -224,7 +226,7 @@
 }
 
 #myTeamContainer {
-
+  margin-top: 1rem;
   section {
     display: grid;
     grid-template-columns: 3fr 2fr;
@@ -254,9 +256,9 @@
     width: 100%;
 
     #rankingTag {
-      border-radius: @radius-base4;
+      border-radius: @radius-base5;
       background-color: rgb(18, 113, 255);
-      padding: 4px 8px;
+      padding: 4px 12px;
       width: fit-content;
       color: white;
       transform: translateY(4px);
@@ -272,9 +274,10 @@
   
   #teamScoreOverview {
     box-shadow: @bx2;
-    border-radius: @radius-base4;
+    border-radius: @radius-base5;
     padding: @padding-base3;
     background-color: rgb(21, 19, 19);
+    
     .statHeader {
       color: gray;
       margin-bottom: 0.6rem;

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -11,7 +11,7 @@
   background: @white;
 
 
-  #portalHeader{
+  #portalHeader {
     .generic-section();
     .constrained-bounds();
     max-width: 1200px !important;
@@ -48,7 +48,7 @@
 
 
   #portalStatsContent {
-    
+
     width: 100%;
     min-height: 120px;
     margin-top: 2rem;
@@ -75,7 +75,7 @@
       background-color: @light-gray;
       box-shadow: @bx3;
       min-height: 140px;
-      padding:  @padding-base2;
+      padding: @padding-base2;
       border-radius: @radius-base4;
       display: flex;
       flex-direction: column;
@@ -84,7 +84,8 @@
       margin-bottom: 2rem;
 
       flex: 1 0 20%;
-      min-width: 100px; /* Ensure items can shrink */
+      min-width: 100px;
+      /* Ensure items can shrink */
       box-sizing: border-box;
 
       span {
@@ -93,7 +94,7 @@
         flex-direction: row;
         align-items: center;
         flex-wrap: wrap;
-        
+
         p {
           color: @text-gray3;
         }
@@ -104,7 +105,7 @@
         font-size: 2.8rem;
         font-weight: @semi-bold;
         margin-top: 1rem;
-      } 
+      }
     }
 
 
@@ -114,17 +115,17 @@
         margin-bottom: 2rem;
       }
     }
-      
+
 
     @media screen and (max-width: @lg) {
-        span p {
-            width: 100%;
-        }
+      span p {
+        width: 100%;
+      }
     }
-  
-    
 
- 
+
+
+
     .portalStatsBox:not(:last-child) {
       margin-right: 2rem;
     }
@@ -135,41 +136,43 @@
       padding: 0;
       margin-left: 2rem;
 
-     span {
+      span {
         display: inline-flex;
         flex-direction: row;
         margin-bottom: 1rem;
+
         p {
           font-weight: @semi-bold;
           width: 100%;
         }
-       
+
       }
 
       #scoreHistoryChart {
         display: flex;
         flex-direction: row;
         align-items: flex-end;
-  
+
         .scoreBar {
           border-radius: @radius-base1;
           background-color: @b2;
           width: 2rem;
           transition: all 0.2s ease-in;
-          
+
         }
-        .scoreBar:hover{
+
+        .scoreBar:hover {
           background-color: @mainred;
         }
 
-  
+
         .scoreBar:not(:last-child) {
           margin-right: 1rem;
         }
       }
     }
 
-    
+
   }
 
   #portalTabContent {
@@ -178,6 +181,7 @@
     height: 100vh;
 
     max-width: 1200px !important;
+
     .ant-tabs-ink-bar {
       display: none;
     }
@@ -188,7 +192,7 @@
     margin-bottom: 5rem;
 
     Input {
-      line-height: 2.5rem ;
+      line-height: 2.5rem;
       font-size: @font3;
     }
   }
@@ -254,7 +258,8 @@
 
     .statHeader {
       color: gray;
-      margin-bottom: 0.6rem;;
+      margin-bottom: 0.6rem;
+      ;
     }
 
     .stat {
@@ -288,12 +293,7 @@
     #teamMembersHeader {
       display: flex;
       justify-content: space-between;
-      // background-color: aqua;
-
-      .heading {
-        margin: 0.6rem;
-        // background-color: greenyellow;
-      }
+      align-items: center;
     }
 
     #teamMember {
@@ -301,10 +301,20 @@
       margin: 1.5rem 1rem;
     }
   }
+
   #teamHeader {
     display: flex;
     margin-bottom: 2rem;
     align-items: center;
   }
-}
 
+  @media screen and (max-width: @sm) {
+    section {
+      display: block
+    }
+
+    #teamAffix {
+      margin-left: 0;
+    }
+  }
+}

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -2,13 +2,44 @@
 @import '../../../newStyles/components.less';
 @import '../../../newStyles/index.less';
 
+
 .CompetitionPortalPage {
   .noContainer();
+
+  
+  // prevents layout shifts caused by scrollbar 
+  overflow-y: hidden;
+  background: @white;
+
 
   #portalHeader{
     .generic-section();
     .constrained-bounds();
     margin-top: 4rem;
+  }
+
+  #portalStatsContent {
+
+
+    p#noTeamMessage {
+      margin-top: 2rem;
+      text-align: left;
+      background: @gray;
+      border-radius: @radius-base4;
+      padding: @padding-base3;
+      max-width: @sm;
+
+    }
+    
+  }
+
+  #portalTabContent {
+    .generic-section();
+    .constrained-bounds();
+
+    .ant-tabs-ink-bar {
+      display: none;
+    }
   }
 
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -281,6 +281,10 @@
       font-weight: bold;
     }
 
+    .inviteCode {
+      background-color: red;
+    }
+
     #teamMembersHeader {
       display: flex;
       justify-content: space-between;
@@ -297,7 +301,6 @@
       margin: 1.5rem 1rem;
     }
   }
-
   #teamHeader {
     display: flex;
     margin-bottom: 2rem;

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -225,6 +225,14 @@
 
 #myTeamContainer {
 
+  section {
+    display: grid;
+    grid-template-columns: 3fr 2fr;
+  }
+
+  .mainHeader {
+    margin: 2rem auto;
+  }
 
   #teamNameInput {
     max-width: 300px;
@@ -234,10 +242,61 @@
     margin-top: 1rem;
   }
 
-  #teamAffix {
+  #teamScoreOverview {
     box-shadow: @bx2;
     border-radius: @radius-base4;
     padding: @padding-base3;
+    background-color: @black;
+
+    .statHeader {
+      color: gray;
+      margin-bottom: 0.6rem;;
+    }
+
+    .stat {
+      font-size: 2.5rem;
+      color: @white;
+    }
+
+    .score {
+      font-size: 3.5rem;
+      color: @white;
+    }
+
+    #teamScoreSpecifics {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      margin-top: 2rem;
+    }
+  }
+
+  #teamAffix {
+    margin-left: 2rem;
+
+    .teamMemberName {
+      font-weight: bold;
+    }
+
+    #teamMembersHeader {
+      display: flex;
+      justify-content: space-between;
+      // background-color: aqua;
+
+      .heading {
+        margin: 0.6rem;
+        // background-color: greenyellow;
+      }
+    }
+
+    #teamMember {
+      display: flex;
+      margin: 1.5rem 1rem;
+    }
+  }
+
+  #teamHeader {
+    display: flex;
+    margin-bottom: 2rem;
   }
 }
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -19,6 +19,9 @@
     margin-top: 4rem;
   }
 
+
+
+
   #portalStatsContent {
 
 
@@ -34,6 +37,8 @@
     }
     
   }
+
+
 
   #portalTabContent {
     .generic-section();
@@ -53,18 +58,14 @@
     } 
   }
 
+}
 
-  .teamPreviewCard {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    background: @gray;
-    padding: @padding-base3 @padding-base2;
-    border-radius: @radius-base4;
+#myTeamContainer {
+  #teamNameInput {
+    max-width: 300px;
   }
 
-
-
+  #makeTeamButton {
+    margin-top: 1rem;
+  }
 }

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -51,7 +51,7 @@
 
 
   #findTeamsContainer {
-
+    margin-bottom: 5rem;
 
     Input {
       line-height: 2.5rem ;
@@ -69,7 +69,7 @@
     width: 100%;
     justify-content: space-between;
     margin-bottom: 1rem;
-    
+
     Button {
       .button-black-square();
     }
@@ -77,6 +77,8 @@
 }
 
 #myTeamContainer {
+
+
   #teamNameInput {
     max-width: 300px;
   }
@@ -86,7 +88,6 @@
   }
 
   #teamAffix {
-    box-sizing: border-box;
     box-shadow: @bx2;
     border-radius: @radius-base4;
     padding: @padding-base3;

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -24,10 +24,11 @@
     p#noTeamMessage {
       margin-top: 2rem;
       text-align: left;
-      background: @gray;
+      background: @black;
       border-radius: @radius-base4;
       padding: @padding-base3;
       max-width: @sm;
+      color: @white;
 
     }
     

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -242,6 +242,13 @@
     margin-top: 1rem;
   }
 
+  #teamNameWrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+
   #teamNameInput {
     max-width: 300px;
   }

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -6,7 +6,6 @@
 .CompetitionPortalPage {
   .noContainer();
 
-  
   // prevents layout shifts caused by scrollbar 
   overflow-y: hidden;
   background: @white;
@@ -15,6 +14,8 @@
   #portalHeader{
     .generic-section();
     .constrained-bounds();
+    max-width: 1200px !important;
+
     margin-top: 4rem;
   }
 
@@ -37,6 +38,8 @@
   #portalTabContent {
     .generic-section();
     .constrained-bounds();
+    max-width: 1200px !important;
+
 
     .ant-tabs-ink-bar {
       display: none;

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -79,11 +79,12 @@
       border-radius: @radius-base4;
       display: flex;
       flex-direction: column;
+      justify-content: space-between;
       transition: background-color 0.2s ease-in;
       margin-bottom: 2rem;
 
       flex: 1 0 20%;
-      min-width: 0; /* Ensure items can shrink */
+      min-width: 100px; /* Ensure items can shrink */
       box-sizing: border-box;
 
       span {
@@ -106,13 +107,22 @@
       } 
     }
 
+
     @media screen and (max-width: @md) {
       .portalStatsBox {
         flex: 1 0 45%;
         margin-bottom: 2rem;
       }
-  
     }
+      
+
+    @media screen and (max-width: @lg) {
+        span p {
+            width: 100%;
+        }
+    }
+  
+    
 
  
     .portalStatsBox:not(:last-child) {
@@ -137,7 +147,7 @@
   
         .scoreBar {
           border-radius: @radius-base1;
-          background-color: darkgray;
+          background-color: @b2;
           width: 2rem;
           transition: all 0.2s ease-in;
           
@@ -193,6 +203,12 @@
       border-radius: @radius-base4;
       padding: @padding-base;
       margin-right: 2rem;
+    }
+
+    @media screen and (max-width: @sm) {
+      p#lastRefreshedText {
+        display: none;
+      }
     }
 
     Button {

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -135,9 +135,15 @@
       padding: 0;
       margin-left: 2rem;
 
-      p {
-        margin-bottom: 2rem;
-        font-weight: @semi-bold;
+     span {
+        display: inline-flex;
+        flex-direction: row;
+        margin-bottom: 1rem;
+        p {
+          font-weight: @semi-bold;
+          width: 100%;
+        }
+       
       }
 
       #scoreHistoryChart {

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -49,7 +49,6 @@
     min-height: 120px;
     margin-top: 2rem;
 
-
     section#noTeamMessage {
       height: 108px;
       text-align: left;
@@ -61,11 +60,14 @@
 
 
     #portalStatsRow {
-      display: flex;
-      flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: repeat(4, minmax(124px, 1fr));
+      gap: 1rem 2rem; // Adjust the gap as needed
       width: 100%;
-      padding: 0;
-  
+
+      @media screen and (max-width: @lg) {
+        grid-template-columns: repeat(auto-fill, minmax(45%, 1fr));
+      }
 
       .portalStatsBox {
         background-color: white;
@@ -76,11 +78,8 @@
         display: flex;
         flex-direction: column;
         justify-content: space-between;
+        margin-bottom: 1rem;
         transition: background-color 0.2s ease-in;
-
-        flex: 1 0 20%;
-        min-width: 124px;
-        box-sizing: border-box;
 
         span {
           display: flex;
@@ -102,72 +101,8 @@
         }
       }
 
-      @media screen and (max-width: @md) {
-        .portalStatsBox {
-          flex: 1 0 45%;
-          margin-right: 0;
-          margin-bottom: 2rem;
-        }
-      }
-
-      .portalStatsBox:not(:last-child) {
-        margin-right: 2rem;
-      }
-
-      .portalStatsBox:last-child {
-        background: none;
-        box-shadow: none;
-        padding: 0;
-        margin-left: 2rem;
-
-        span {
-          display: inline-flex;
-          flex-direction: row;
-          margin-bottom: 1rem;
-
-          p {
-            font-weight: @semi-bold;
-            width: 100%;
-          }
-
-        }
-
-        #scoreHistoryChart {
-          display: flex;
-          flex-direction: row;
-          align-items: flex-end;
-
-          .scoreBar {
-            border-radius: @radius-base1;
-            background-color: @black;
-            width: 2rem;
-            transition: all 0.2s ease-in;
-            cursor: pointer;
-          }
-
-          .scoreBar:hover {
-            background-color: @mainred;
-          }
-
-
-          .scoreBar:not(:last-child) {
-            margin-right: 1rem;
-          }
-        }
-      }
     }
   }
-
-
-
-
-    @media screen and (max-width: @lg) {
-      span p {
-        width: 100%;
-      }
-    }
-
-
 
 
 
@@ -182,13 +117,11 @@
       background-color: @mainred;
     }
 
-  
   }
 
 
   #findTeamsContainer {
     margin-top: 1rem;
-
     margin-bottom: 5rem;
 
     Input {
@@ -202,6 +135,7 @@
 
 #leaderBoardContainer {
   margin-top: 1rem;
+
   section {
     display: inline-flex;
     width: 100%;
@@ -227,157 +161,157 @@
   }
 }
 
+
+
+
 #myTeamContainer {
   margin-top: 1rem;
-  section {
+
+  section:first-of-type {
     display: grid;
-    grid-template-columns: 3fr 2fr;
+    grid-template-columns: minmax(400px, 3fr) 2fr;
   }
 
-  .mainHeader {
-    margin: 2rem auto;
-  }
+  div#teamMainContent {
+    .mainHeader {
+      margin: 2rem auto;
+    }
 
-  #submitFileButton  {
-    margin-top: 1rem;
-    .button-black-square();
-  }
+    #submitFileButton {
+      margin-top: 1rem;
+      .button-black-square();
+    }
 
-  #makeTeamButton {
-    margin-top: 1rem;
-    width: fit-content;
-  }
-  #leaveTeamButton {
-    border: none;
-  }
-
-  #teamNameWrapper {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-
-    #rankingTag {
-      border-radius: @radius-base5;
-      background-color: rgb(18, 113, 255);
-      padding: 4px 12px;
+    #makeTeamButton {
+      margin-top: 1rem;
       width: fit-content;
-      color: white;
-      transform: translateY(4px);
-      box-sizing: border-box;
-      font-weight: @semi-bold;
-    }
-  }
-
-  #teamNameInput {
-    max-width: 300px;
-  }
-
-  
-  #teamScoreOverview {
-    box-shadow: @bx2;
-    border-radius: @radius-base5;
-    padding: @padding-base3;
-    background-color: rgb(21, 19, 19);
-    
-    .statHeader {
-      color: gray;
-      margin-bottom: 0.6rem;
-      ;
     }
 
-    .stat {
-      font-size: 2.5rem;
-      color: @white;
+    #leaveTeamButton {
+      border: none;
     }
 
-    .score {
-      font-size: 3.5rem;
-      color: @white;
-    }
-
-    #teamScoreSpecifics {
-      display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
-      margin-top: 2rem;
-    }
-  }
-
-  #teamHeader {
-    display: flex;
-    margin-bottom: 2rem;
-    align-items: center;
-
-    h3 {
-      font-weight: @semi-bold;
-    }
-  }
-
-  #uploadFileSection, #submissionLogSection {
-    display: block;
-    margin-top: 5rem;
-  }
-
-  #submissionCountDown {
-    background-color: @light-gray;
-    border-radius: @radius-base3;
-    padding: 10px;
-    display: inline-block;
-    margin-left: 1rem;
-  }
-
-  #teamAffix {
-    margin-top: 1rem;
-    height: fit-content;
-    box-sizing: border-box;
-    padding: @padding-base3;
-    background-color: @light-gray;
-    margin-left: 2rem;
-    border-radius: @radius-base4;
-
-    #teamMembersHeader {
+    #teamNameWrapper {
       display: flex;
       justify-content: space-between;
       align-items: center;
+      width: 100%;
 
-        
-      #inviteButton {
-        .button-black-square();
+      #rankingTag {
+        border-radius: @radius-base5;
+        background-color: rgb(18, 113, 255);
+        padding: 4px 12px;
+        width: fit-content;
+        font-size: 1.1rem;
+        color: white;
+        transform: translateY(4px);
+        box-sizing: border-box;
+        font-weight: @semi-bold;
       }
-
-      .inviteCode {
-        background-color: red;
-      }
-
-
     }
 
-    div.teamMember {
+    #teamNameInput {
+      max-width: 300px;
+    }
+
+
+
+    #teamHeader {
       display: flex;
-      padding: 8px;
-      background: none;
-      border-radius: @radius-base4;
-      margin: 1rem 0rem 1rem 0;
-      transition: 0.2s ease-in;
+      margin-bottom: 2rem;
+      align-items: center;
 
-      .teamMemberName {
-        font-weight: bold;
+      h3 {
+        font-weight: @semi-bold;
       }
     }
 
-    div.teamMember:hover {
-        background-color: white !important;
-        cursor: pointer;
+    #uploadFileSection,
+    #submissionLogSection,
+    #teamScoreHistorySection {
+      display: block;
+      margin-top: 5rem;
     }
+
+    #teamScoreHistorySection {
+      
+      h3 {
+        font-weight: @semi-bold;
+      }
+    }
+
+    #submissionCountDown {
+      background-color: @light-gray;
+      border-radius: @radius-base3;
+      padding: 10px;
+      display: inline-block;
+      margin-left: 1rem;
+    }
+
+
   }
 
-  @media screen and (max-width: @md) {
-    section {
-      display: block
-    }
 
-    #teamAffix {
-      margin-left: 0;
+
+
+
+  div#sideContent {
+    margin-top: 1rem;
+    margin-left: 2rem;
+    height: fit-content;
+
+
+    div#membersBox {
+      height: fit-content;
+      box-sizing: border-box;
+      padding: @padding-base3;
+      background-color: @light-gray;
+      border-radius: @radius-base4;
+
+
+      #teamMembersHeader {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+
+        #inviteButton {
+          .button-black-square();
+        }
+
+        .inviteCode {
+          background-color: red;
+        }
+      }
+
+      div.teamMember {
+        display: flex;
+        padding: 8px;
+        background: none;
+        border-radius: @radius-base4;
+        margin: 1rem 0rem 1rem 0;
+        transition: 0.2s ease-in;
+
+        .teamMemberName {
+          font-weight: bold;
+        }
+      }
+
+      div.teamMember:hover {
+        background-color: white !important;
+        cursor: pointer;
+      }
     }
+  }
+}
+
+
+@media screen and (max-width: @lg) {
+  #myTeamContainer section:first-of-type {
+    display: block;
+  }
+
+  div#sideContent {
+    margin-left: 0 !important;
   }
 }

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -7,10 +7,6 @@
   .noContainer();
   height: 100vh;
 
-  // prevents layout shifts caused by scrollbar 
-  background: @white;
-
-
   #portalHeader {
     .generic-section();
     .constrained-bounds();
@@ -72,7 +68,7 @@
     }
 
     .portalStatsBox {
-      background-color: @light-gray;
+      background-color: white;
       box-shadow: @bx3;
       min-height: 140px;
       padding: @padding-base2;
@@ -81,7 +77,6 @@
       flex-direction: column;
       justify-content: space-between;
       transition: background-color 0.2s ease-in;
-      margin-bottom: 2rem;
 
       flex: 1 0 20%;
       min-width: 100px;
@@ -155,10 +150,10 @@
 
         .scoreBar {
           border-radius: @radius-base1;
-          background-color: @b2;
+          background-color: @black;
           width: 2rem;
           transition: all 0.2s ease-in;
-
+          cursor: pointer;
         }
 
         .scoreBar:hover {
@@ -179,12 +174,13 @@
     .generic-section();
     .constrained-bounds();
     height: 100vh;
-
     max-width: 1200px !important;
 
     .ant-tabs-ink-bar {
       display: none;
     }
+
+  
   }
 
 
@@ -238,8 +234,17 @@
     margin: 2rem auto;
   }
 
-  .submitButton {
+  #submitFileButton  {
     margin-top: 1rem;
+    .button-black-square();
+  }
+
+  #makeTeamButton {
+    margin-top: 1rem;
+    width: fit-content;
+  }
+  #leaveTeamButton {
+    border: none;
   }
 
   #teamNameWrapper {
@@ -247,22 +252,29 @@
     justify-content: space-between;
     align-items: center;
     width: 100%;
+
+    #rankingTag {
+      border-radius: @radius-base4;
+      background-color: rgb(18, 113, 255);
+      padding: 4px 8px;
+      width: fit-content;
+      color: white;
+      transform: translateY(4px);
+      box-sizing: border-box;
+      font-weight: @semi-bold;
+    }
   }
 
   #teamNameInput {
     max-width: 300px;
   }
 
-  #makeTeamButton {
-    margin-top: 1rem;
-  }
-
+  
   #teamScoreOverview {
     box-shadow: @bx2;
     border-radius: @radius-base4;
     padding: @padding-base3;
-    background-color: @black;
-
+    background-color: rgb(21, 19, 19);
     .statHeader {
       color: gray;
       margin-bottom: 0.6rem;
@@ -286,36 +298,75 @@
     }
   }
 
+  #teamHeader {
+    display: flex;
+    margin-bottom: 2rem;
+    align-items: center;
+
+    h3 {
+      font-weight: @semi-bold;
+    }
+  }
+
+  #uploadFileSection, #submissionLogSection {
+    display: block;
+    margin-top: 5rem;
+  }
+
+  #submissionCountDown {
+    background-color: @light-gray;
+    border-radius: @radius-base3;
+    padding: 10px;
+    display: inline-block;
+    margin-left: 1rem;
+  }
+
   #teamAffix {
+    margin-top: 1rem;
+    height: fit-content;
+    box-sizing: border-box;
+    padding: @padding-base3;
+    background-color: @light-gray;
     margin-left: 2rem;
-
-    .teamMemberName {
-      font-weight: bold;
-    }
-
-    .inviteCode {
-      background-color: red;
-    }
+    border-radius: @radius-base4;
 
     #teamMembersHeader {
       display: flex;
       justify-content: space-between;
       align-items: center;
+
+        
+      #inviteButton {
+        .button-black-square();
+      }
+
+      .inviteCode {
+        background-color: red;
+      }
+
+
     }
 
-    #teamMember {
+    div.teamMember {
       display: flex;
-      margin: 1.5rem 1rem;
+      padding: 8px;
+      background: none;
+      border-radius: @radius-base4;
+      margin: 1rem 0rem 1rem 0;
+      transition: 0.2s ease-in;
+
+      .teamMemberName {
+        font-weight: bold;
+      }
+    }
+
+    div.teamMember:hover {
+        background-color: white !important;
+        cursor: pointer;
     }
   }
 
-  #teamHeader {
-    display: flex;
-    margin-bottom: 2rem;
-    align-items: center;
-  }
-
-  @media screen and (max-width: @sm) {
+  @media screen and (max-width: @md) {
     section {
       display: block
     }

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -16,62 +16,137 @@
     .constrained-bounds();
     max-width: 1200px !important;
     margin-top: 4rem;
+
+    span {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+
+      Button {
+        .button-black-square();
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+
+    #portalBanner {
+      .gradient();
+      border-radius: @radius-base4;
+      padding: @padding-base2;
+      margin-top: 1rem;
+      box-sizing: border-box;
+
+      p {
+        color: white;
+      }
+    }
   }
 
 
 
 
   #portalStatsContent {
+    
     width: 100%;
+    min-height: 120px;
     margin-top: 2rem;
 
 
     section#noTeamMessage {
-      min-height: 100px;
+      height: 108px;
       text-align: left;
-      align-items: center;
-      background: @black;
-      border-radius: @radius-base4;
+      align-items: start;
       padding: @padding-base2;
       max-width: @sm;
-      color: @white;
+      color: @black;
     }
 
-    section {
-      display: inline-flex;
-    }
-    .portalStatsBox {
-      min-height: 100px;
+
+    #portalStatsRow {
+      display: flex;
+      flex-wrap: wrap;
       width: 100%;
+      justify-content: space-between;
+    }
+
+    .portalStatsBox {
+      background-color: @light-gray;
+      box-shadow: @bx3;
+      box-sizing: border-box;
+      height: 140px;
       padding:  @padding-base2;
       border-radius: @radius-base4;
       display: flex;
       flex-direction: column;
+      transition: background-color 0.2s ease-in;
+      margin-bottom: 2rem;
 
-      h3, p {
-        color: white;
+      flex: 1 0 20%;
+      min-width: 0; /* Ensure items can shrink */
+      box-sizing: border-box;
+
+      p {
+        color: @black;
       }
+
+      p:nth-of-type(2) {
+        font-size: 2.8rem;
+        font-weight: @semi-bold;
+        margin-top: 1rem;
+      } 
     }
 
-
-    .portalStatsBox:first-child {
-      background-color: @p3;
-    }
-
-    .portalStatsBox:not(:first-child) {
-      background-color: @light-gray;
-      h3, p {
-        color: black;
+    @media screen and (max-width: @md) {
+      .portalStatsBox {
+        flex: 1 0 45%;
+        margin-bottom: 2rem;
       }
+  
     }
 
+ 
     .portalStatsBox:not(:last-child) {
       margin-right: 2rem;
     }
+
+    .portalStatsBox:last-child {
+      background: none;
+      box-shadow: none;
+      padding: 0;
+      margin-left: 2rem;
+
+      p {
+        margin-bottom: 2rem;
+        font-weight: @semi-bold;
+      }
+
+      #scoreHistoryChart {
+        display: flex;
+        flex-direction: row;
+        align-items: flex-end;
+  
+        .scoreBar {
+          border-radius: @radius-base1;
+          background-color: darkgray;
+          width: 2rem;
+          transition: all 0.2s ease-in;
+          
+        }
+        .scoreBar:hover{
+          background-color: @mainred;
+        }
+
+  
+        .scoreBar:not(:last-child) {
+          margin-right: 1rem;
+        }
+      }
+    }
+
     
   }
-
-
 
   #portalTabContent {
     .generic-section();

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -43,5 +43,17 @@
   }
 
 
+  .teamPreviewCard {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    background: @gray;
+    padding: @padding-base3 @padding-base2;
+    border-radius: @radius-base4;
+  }
+
+
 
 }

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -74,8 +74,7 @@
     .portalStatsBox {
       background-color: @light-gray;
       box-shadow: @bx3;
-      box-sizing: border-box;
-      height: 140px;
+      min-height: 140px;
       padding:  @padding-base2;
       border-radius: @radius-base4;
       display: flex;
@@ -87,11 +86,20 @@
       min-width: 0; /* Ensure items can shrink */
       box-sizing: border-box;
 
-      p {
-        color: @black;
+      span {
+        display: flex;
+        justify-content: start;
+        flex-direction: row;
+        align-items: center;
+        flex-wrap: wrap;
+        
+        p {
+          color: @text-gray3;
+        }
+
       }
 
-      p:nth-of-type(2) {
+      p.stat {
         font-size: 2.8rem;
         font-weight: @semi-bold;
         margin-top: 1rem;

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -126,7 +126,7 @@
     
     Input {
       line-height: 2.5rem;
-      font-size: minmax(14px, 6rem);
+      font-size: 16px;
     }
   }
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { AutoComplete, Avatar, Col, Drawer, Form, List, Row, Skeleton, Tabs, message } from "antd";
+import { Affix, AutoComplete, Avatar, Col, Drawer, Form, List, Row, Skeleton, Tabs, message } from "antd";
 import { Layout, Space, Button, Input, Modal } from 'antd';
 import UserContext, { User } from "../../../UserContext";
 import { useHistory } from 'react-router-dom';
@@ -15,6 +15,7 @@ import path from 'path';
 import DefaultLayout from "../../../components/layouts/default";
 import { PaginationPosition, PaginationAlign } from "antd/es/pagination/Pagination";
 import { registerCompetitionUser } from "../../../actions/competition";
+import { genColor } from "../../../utils/colors";
 const { Content } = Layout;
 
 
@@ -112,9 +113,32 @@ const LeaderBoardTab = ( ) => {
 
     const [isLoading, setIsLoading] =  useState<boolean>(false);
     const [newTeamName, setNewTeamName] = useState("");
+    
     useEffect(() => {
 
     }, []);
+
+
+
+    const generateTeamPicture = () => {
+
+        const color1 = genColor(compUser.competitionTeam.teamName);
+        const color2 = genColor(`${compUser.competitionTeam.teamName}_additional_seed`);
+
+        return (
+            <div 
+            style={{
+                display: 'inline-block',
+                verticalAlign: 'middle',
+                borderRadius: '50%',
+                width: '4rem',
+                height:'4rem',
+                background: `linear-gradient(30deg, ${color1}, ${color2})`,
+                marginRight: '0.75rem',
+              }}>
+            </div>
+        )
+    }
 
     const handleClick = () => {
 
@@ -135,8 +159,6 @@ const LeaderBoardTab = ( ) => {
         });
 
         setIsLoading(false);
-
-
     }
 
     return (
@@ -160,12 +182,25 @@ const LeaderBoardTab = ( ) => {
                     Make Team
                 </Button>
             </section>
+            
 
         ) }
 
         {compUser.competitionTeam !== null && (
             <section>
-                <h3>{compUser.competitionTeam.teamName}</h3>
+                <span>
+                    {generateTeamPicture()}
+                        <h3>{compUser.competitionTeam.teamName}</h3>
+
+                </span>
+                
+                <Affix style={{ position: 'absolute', top: 10, right: 0 }} offsetTop={100}>
+                    <div id = "teamAffix">
+
+                    <h3>Members</h3>
+                    <p>Description</p>
+                    </div>
+                </Affix>
             </section>
         )}
       </Content>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -23,19 +23,26 @@ const { Content } = Layout;
 const teamCard = (team: any): React.ReactNode => {
     return (
         <div id = {team.teamID} className = "teamPreviewCard">
-            <h3>{team.teamName}</h3>
+            <h3><strong>{team.teamName}</strong></h3>
             <p>{team.teamMembers.length} members</p>
             {/* {team.teamMembers.map((member: string, index: number) => (
                 <p key={index}>{member}</p>
             ))} */}
+
+
+            {/** Clicking the button should open a modal to display team details and the option to join if user isn't part of team yet */}
+            <Button size="large" shape="round">
+                
+                <p>View</p>
+            </Button>
         </div>
     );
 };
 
 
 const FindTeamsTab = (data: Array<Object>): React.ReactNode => {
-    const [position, setPosition] = useState<PaginationPosition>('bottom');
-    const [align, setAlign] = useState<PaginationAlign>('center');
+    const [position] = useState<PaginationPosition>('bottom');
+    const [align] = useState<PaginationAlign>('center');
   
     return (
       <Content id="findTeamsContainer" className = "portalTabContent">

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -829,7 +829,6 @@ function CompetitionPortalPage() {
 
                                         <div className="portalStatsBox">
                                             <span>
-                                                {/* <BiStats size={24} style={{ padding: "4px", borderRadius: "8px", color: "#fe8019", background: "#FCC777", marginRight: "1rem" }} /> */}
                                                 <BiStats size={24} style={{ padding: "4px", borderRadius: "8px", color: "white", background: "black", marginRight: "1rem" }} />
                                                 <p>Best Score</p>
                                             </span>
@@ -839,7 +838,6 @@ function CompetitionPortalPage() {
 
                                         <div className="portalStatsBox">
                                             <span>
-                                                {/* <FaStar size={20} style={{ padding: "6px", borderRadius: "8px", color: "red", background: "pink", marginRight: "1rem" }} /> */}
                                                 <FaStar size={20} style={{ padding: "6px", borderRadius: "8px", color: "white", background: "black", marginRight: "1rem" }} />
                                                 <p>Ranking</p>
                                             </span>
@@ -848,57 +846,11 @@ function CompetitionPortalPage() {
 
                                         <div className="portalStatsBox">
                                             <span>
-                                                {/* <FaStar size={20} style={{ padding: "6px", borderRadius: "8px", color: "red", background: "pink", marginRight: "1rem" }} /> */}
                                                 <FaStar size={20} style={{ padding: "6px", borderRadius: "8px", color: "white", background: "black", marginRight: "1rem" }} />
                                                 <p>Matches Played</p>
                                             </span>
                                             <p className="stat">0</p>
                                         </div>
-
-                                        {/* <div className="portalStatsBox">
-                                            <span>
-                                                <p>Score History</p>
-                                                {scoreHistoryPercentage ?
-                                                    <Statistic
-                                                        value={Math.abs(scoreHistoryPercentage)}
-                                                        precision={2}
-                                                        valueStyle={{ color: scoreHistoryPercentage < 0 ? '#cf1322' : '#3f8600', fontSize: "1.2rem", display: "inline" }}
-                                                        prefix={scoreHistoryPercentage < 0 ? <ArrowDownOutlined /> : <ArrowUpOutlined />}
-                                                        suffix="%"
-                                                    />
-                                                    :
-                                                    <></>
-                                                }
-                                            </span>
-                                            <div id="scoreHistoryChart">
-                                                {barHeights.length > 0 ?
-                                                    <>
-                                                        {barHeights.map((height: number, index: any) => (
-                                                            <Tooltip title={height}>
-                                                                <div
-                                                                    key={index}
-                                                                    className="scoreBar"
-                                                                    style={{ height: `${height * scale}px` }}
-                                                                ></div>
-
-                                                            </Tooltip>
-                                                        ))}
-                                                        {Array.from({ length: 7 - barHeights.length }, (index: any) => (
-                                                            <div
-                                                                key={index}
-                                                                className="scoreBar"
-                                                                style={{ height: `92px`, backgroundColor: "lightgrey" }}
-                                                            ></div>
-
-                                                        ))}
-                                                    </>
-                                                    :
-                                                    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
-                                                }
-                                            </div>
-
-                                        </div> */}
-
                                     </section>
                                 }
                             </>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { Affix, AutoComplete, Statistic, Drawer, List, Skeleton, Tabs, Tooltip, message } from "antd";
+import { Affix, AutoComplete, Statistic, Drawer, List, Skeleton, Tabs, Tooltip, message, Empty } from "antd";
 import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
 import { Layout, Button, Input, Modal } from 'antd';
 import UserContext, { User } from "../../../UserContext";
@@ -640,25 +640,43 @@ function CompetitionPortalPage ()  {
                                         <div className = "portalStatsBox">
                                             <span>
                                                 <p>Score History</p>
-                                                <Statistic
-                                                    value={Math.abs(scoreHistoryPercentage)}
-                                                    precision={2}
-                                                    valueStyle={{ color: scoreHistoryPercentage < 0 ? '#cf1322' : '#3f8600', fontSize: "1.2rem", display:"inline" }}
-                                                    prefix={ scoreHistoryPercentage < 0 ?  <ArrowDownOutlined /> : <ArrowUpOutlined /> }
-                                                    suffix="%"
-                                                />
+                                                {scoreHistoryPercentage  ? 
+                                                    <Statistic
+                                                        value={Math.abs(scoreHistoryPercentage)}
+                                                        precision={2}
+                                                        valueStyle={{ color: scoreHistoryPercentage < 0 ? '#cf1322' : '#3f8600', fontSize: "1.2rem", display:"inline" }}
+                                                        prefix={ scoreHistoryPercentage < 0 ?  <ArrowDownOutlined /> : <ArrowUpOutlined /> }
+                                                        suffix="%"
+                                                    />
+                                                    :
+                                                   <></>
+                                                }
                                             </span>
                                             <div id = "scoreHistoryChart">
-                                                {barHeights.map((height:number, index:any) => (
-                                                    <Tooltip title={height}>
+                                                {barHeights.length > 0 ?
+                                                    <>
+                                                    {barHeights.map((height:number, index:any) => (
+                                                        <Tooltip title={height}>
+                                                            <div
+                                                                key={index}
+                                                                className="scoreBar"
+                                                                style={{ height: `${height * scale}px`}}
+                                                            ></div>
+
+                                                        </Tooltip>
+                                                    ))}
+                                                    {Array.from({ length: 7 - barHeights.length }, (index : any) => (
                                                         <div
                                                             key={index}
                                                             className="scoreBar"
-                                                            style={{ height: `${height * scale}px`}}
+                                                            style={{ height: `92px`, backgroundColor: "lightgrey"}}
                                                         ></div>
 
-                                                    </Tooltip>
-                                                ))}
+                                                    ))}
+                                                    </>
+                                                    :
+                                                    <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                                                }
                                             </div>
             
                                         </div>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -511,7 +511,7 @@ const MyTeamTab = ({ isLoadingTeamInfo, compUser, rankData, teamInfo, metaData ,
 
                         </div>
 
-                        <div>
+                        <div id = "matchesBox">
                             <h3  className="heading" style = {{marginRight: "1rem", fontWeight: 800}}>Matches</h3>
                         </div>
                     </div>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { AutoComplete, Avatar, Col, Form, List, Tabs, message } from "antd";
+import { AutoComplete, Avatar, Col, Drawer, Form, List, Row, Skeleton, Tabs, message } from "antd";
 import { Layout, Space, Button, Input, Modal } from 'antd';
 import UserContext, { User } from "../../../UserContext";
 import { useHistory } from 'react-router-dom';
@@ -15,7 +15,6 @@ import path from 'path';
 import DefaultLayout from "../../../components/layouts/default";
 import { PaginationPosition, PaginationAlign } from "antd/es/pagination/Pagination";
 import { registerCompetitionUser } from "../../../actions/competition";
-import { useForm } from "react-hook-form";
 const { Content } = Layout;
 
 
@@ -30,7 +29,6 @@ const FindTeamsTab = (
 
     // dropdown options for search bar
     const [options, setOptions] = useState<Array<Object>>(data);
-
 
     // Initialize the teams data once that data defined
     useEffect(() => {
@@ -94,7 +92,7 @@ const FindTeamsTab = (
 };
 
   
-const LeaderBoardTab = () => {
+const LeaderBoardTab = ( ) => {
     return (
       <Content id="leaderBoardContainer" className = "portalTabContent">
             <h2>Leaderboard</h2>
@@ -103,10 +101,63 @@ const LeaderBoardTab = () => {
 };
 
 
-  const MyTeamTab = () => {
+  const MyTeamTab = ( { compUser, fetchTeamsCallback}: {compUser: any, fetchTeamsCallback: () => void}) => {
+
+    const [isLoading, setIsLoading] =  useState<boolean>(false);
+    const [newTeamName, setNewTeamName] = useState("");
+    useEffect(() => {
+
+    }, []);
+
+    const handleClick = () => {
+
+        if(newTeamName.length == 0) {
+            message.info('Name cannot be empty');
+            return;
+        }
+
+        setIsLoading(true);
+        createTeam(compUser.competitionName, compUser.username, newTeamName).then((res) => {
+            message.success('Successfully made a new team!');
+            fetchTeamsCallback();
+        
+        })
+        .catch((error) => {
+            message.error(error.message);
+        });
+        setIsLoading(false);
+
+    }
+
     return (
       <Content id="myTeamContainer" className = "portalTabContent">
-        <h2>My Team</h2>
+        {compUser.competitionTeam == null && (
+
+            <section>
+                <Input 
+                    id = "teamNameInput" 
+                    placeholder="New Team Name" 
+                    size = "large"
+                    onChange={(e) => setNewTeamName(e.target.value)}
+                    >
+                </Input><br/>
+                <Button 
+                    type = "primary" 
+                    size = "large" id = "makeTeamButton" 
+                    loading = {isLoading} 
+                    onClick={handleClick} 
+                >
+                    Make Team
+                </Button>
+            </section>
+
+        ) }
+
+        {compUser.competitionTeam !== null && (
+            <section>
+                <h3>{compUser.competitionTeam.teamName}</h3>
+            </section>
+        )}
       </Content>
     );
   };
@@ -131,7 +182,6 @@ function CompetitionPortalPage ()  {
     }
 
     const [isModalOpen, setIsModalOpen] = useState(false);
-    const { handleSubmit } = useForm();
 
      // Modal props
      const showModal = () => {
@@ -270,13 +320,16 @@ function CompetitionPortalPage ()  {
                                 {
                                     label: <p>My Team</p>,
                                     key: '3',
-                                    children: MyTeamTab(),
+                                    children: <MyTeamTab 
+                                        compUser={compUser} 
+                                        fetchTeamsCallback={fetchTeams} />,
                                 },
                             ]
                         }
                     ></Tabs>
                 </Content>
             </Content>
+
         </DefaultLayout>
     );
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useEffect } from "react";
-import { List, Tabs, message } from "antd";
+import React, { useContext, useEffect, useState } from "react";
+import { Avatar, List, Tabs, message } from "antd";
 import { Layout, Space, Button } from 'antd';
 import UserContext from "../../../UserContext";
 import { useHistory } from 'react-router-dom';
@@ -7,21 +7,49 @@ import {
     getTeamInfo,
     createTeam,
     getCompetitionUser,
+    getTeams,
   } from '../../../actions/teams/utils';
 
 import './index.less';
 import path from 'path';
 
 import DefaultLayout from "../../../components/layouts/default";
+import { PaginationPosition, PaginationAlign } from "antd/es/pagination/Pagination";
+import { all } from "axios";
 
 const { Content } = Layout;
 
 
+const teamCard = (team: any): React.ReactNode => {
+    return (
+        <div id = {team.teamID} className = "teamPreviewCard">
+            <h3>{team.teamName}</h3>
+            <p>{team.teamMembers.length} members</p>
+            {/* {team.teamMembers.map((member: string, index: number) => (
+                <p key={index}>{member}</p>
+            ))} */}
+        </div>
+    );
+};
 
-const FindTeamsTab = (): React.ReactNode => {
+
+const FindTeamsTab = (data: Array<Object>): React.ReactNode => {
+    const [position, setPosition] = useState<PaginationPosition>('bottom');
+    const [align, setAlign] = useState<PaginationAlign>('center');
+  
     return (
       <Content id="findTeamsContainer" className = "portalTabContent">
-        <h2>Find Teams</h2>
+        <List
+            split = {false}
+            pagination={{ position, align}}
+            dataSource={data}
+            renderItem={(item: any) => (
+            <List.Item key = {item.competitionName}>
+                {teamCard(item)}
+
+            </List.Item>
+            )}
+        />
 
       </Content>
     );
@@ -35,7 +63,7 @@ const LeaderBoardTab = (): React.ReactNode => {
 
       </Content>
     );
-  };
+};
 
 
   const MyTeamTab = (): React.ReactNode => {
@@ -51,6 +79,8 @@ const LeaderBoardTab = (): React.ReactNode => {
 function CompetitionPortalPage ()  {
     const history = useHistory();
     const { user } = useContext(UserContext);
+    const [allTeams, setAllTeams] = useState<Array<Object>>([]);
+
 
     const tabItems= [
         {
@@ -61,29 +91,36 @@ function CompetitionPortalPage ()  {
         {
             label: <p>Find Teams</p>,
             key: '2',
-            children: FindTeamsTab(),
+            children: FindTeamsTab(allTeams),
         },
         {
             label: <p>My Team</p>,
             key: '3',
             children: MyTeamTab(),
         }
-        ];
+    ];
 
     useEffect(() => {
         if (!user.loggedIn) {
           message.info('You need to login to upload predictions and participate');
           history.replace(path.join(window.location.pathname, '../../../login'));
         }
-      }, []);
 
-
-      useEffect(() => {
-        if (!user.loggedIn) {
-          message.info('You need to login to upload predictions and participate');
-          history.replace(path.join(window.location.pathname, '../../../login'));
+        else {
+            
+            getTeams("TestCompetition2").then(res => {
+                if(res.data) {
+                    setAllTeams(Array.from(res.data))
+                    console.log(Array.from(res.data));
+                }
+            })
+            .catch(error => {
+                console.log(error);
+            });
         }
+        
       }, []);
+
     
     return (
         <DefaultLayout>
@@ -101,18 +138,32 @@ function CompetitionPortalPage ()  {
                     </section>
                 </Content>
 
-                
-
-    
             
-
                 <Content id = "portalTabContent">
                     {/* If the user is not part of a team yet, then */}
                     <Tabs
                         size="small"
                         animated={true}
                         tabPosition="top"
-                        items={tabItems}
+                        items={
+                            [
+                                {
+                                    label: <p>Leaderboard</p>,
+                                    key: '1',
+                                    children: LeaderBoardTab(),
+                                },
+                                {
+                                    label: <p>Find Teams</p>,
+                                    key: '2',
+                                    children: FindTeamsTab(allTeams),
+                                },
+                                {
+                                    label: <p>My Team</p>,
+                                    key: '3',
+                                    children: MyTeamTab(),
+                                }
+                            ]
+                        }
                     ></Tabs>
                 </Content>
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
-import { Affix, AutoComplete, Statistic, Drawer, List, Skeleton, Tabs, Tooltip, message, Empty } from "antd";
-import { ArrowDownOutlined, ArrowUpOutlined, PlusOutlined, InboxOutlined } from '@ant-design/icons';
-import { Form, Layout, Button, Input, Modal, Upload } from 'antd';
+import React, { useContext, useEffect, useState } from "react";
+import { AutoComplete, Drawer, List, Skeleton, Tabs, message, Empty } from "antd";
+import { InboxOutlined } from '@ant-design/icons';
+import { Layout, Button, Input, Modal, Upload } from 'antd';
 import type { UploadProps } from 'antd';
 import UserContext, { User } from "../../../UserContext";
 import { useHistory } from 'react-router-dom';
@@ -15,8 +15,6 @@ import {
 import TeamCard from '../../../components/TeamCard/index';
 import './index.less';
 import path from 'path';
-import moment from 'moment';
-import ChartJS from 'chart.js';
 import DefaultLayout from "../../../components/layouts/default";
 import { PaginationPosition, PaginationAlign } from "antd/es/pagination/Pagination";
 import { CompetitionData, getLeaderboard, getMetaData, getRanks, registerCompetitionUser, uploadSubmission } from "../../../actions/competition";
@@ -25,7 +23,6 @@ import { IoHelp, IoSearch } from "react-icons/io5";
 import { IoEllipsisVertical , IoPersonAdd} from "react-icons/io5";
 import { FaCheck, FaStar } from "react-icons/fa";
 import Table, { ColumnsType } from "antd/es/table";
-import { AxiosResponse } from "axios";
 import { BiStats } from "react-icons/bi";
 
 import { createAvatar } from '@dicebear/core';
@@ -566,11 +563,6 @@ function CompetitionPortalPage() {
     const [isLoadingLeaderBoard, setIsLoadingLeaderBoard] = useState(false);
     const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
 
-
-    const [barHeights, setBarHeights] = useState<number[]>([]);
-    const [scoreHistoryPercentage, setScoreHistoryPercentage] = useState<number>(0);
-    const [scale, setScale] = useState<number>(1);
-
     // meta data for current competition
     const [metaData, setMetaData] = useState<{
         competitionName: string;
@@ -744,36 +736,6 @@ function CompetitionPortalPage() {
      */
     useEffect(() => {
         updateRankings();
-
-        if (teamInfo !== null) {
-            console.log("setting bar chart")
-            // update the score history chart here
-            if (teamInfo.scoreHistory) {
-                let scores = teamInfo.scoreHistory.slice(-7);
-                scores = scores.map(Number);
-                setBarHeights(scores);
-
-                // Find the maximum score
-                const maxScore = Math.max(...scores);
-
-                // Find relative growth of scores
-                let lastTwo = scores.slice(-2);
-                
-                const diff = lastTwo[1] - lastTwo[0];
-                const percent = diff / lastTwo[0];
-                setScoreHistoryPercentage(percent);
-
-                // Set your desired maximum height for the bars
-                const maxBarHeight = 92;
-
-                // Calculate the scaling factor
-                const scalingFactor = maxBarHeight / maxScore;
-                setScale(scalingFactor);
-                console.log(teamInfo.scoreHistory);
-
-            }
-
-        }
 
     }, [teamInfo]);
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -17,6 +17,7 @@ import { PaginationPosition, PaginationAlign } from "antd/es/pagination/Paginati
 import { CompetitionData, getLeaderboard, getMetaData, getRanks, registerCompetitionUser } from "../../../actions/competition";
 import { genColor } from "../../../utils/colors";
 import Table, { ColumnsType } from "antd/es/table";
+import MainFooter from "../../../components/MainFooter";
 const { Content } = Layout;
 
 
@@ -270,6 +271,7 @@ const MyTeamTab = ( { compUser, fetchTeamsCallback}: {compUser: any, fetchTeamsC
                 </Affix>
             </section>
         )}
+        
       </Content>
     );
   };
@@ -484,28 +486,30 @@ function CompetitionPortalPage ()  {
                          ):
                           (  <>
                                 {compUser.competitionTeam == null ? 
-                                    <p id = "noTeamMessage">
+                                    <section id = "noTeamMessage">
+                                        <p>
                                         Uh oh! You’re not in a team yet. Either make your own team or ask your friends to share their invite code, 
                                         then navigate to Find Teams below to join their group!
-                                    </p>
-                                
+                                        </p>
+                                    </section>
+                                    
                                 : 
-                                <section>
-                                    <div className = "portalStatsBox">
-                                        <h3>Your Total Submissions</h3>
-                                    </div>
+                                    <section id = "portalStatsRow">
+                                        <div className = "portalStatsBox">
+                                            <h3>Your Total Submissions</h3>
+                                        </div>
 
-                                    <div className = "portalStatsBox">
-                                        <h3>Team Score</h3>
-                                        <p>{userRankData.score}</p>
-                                    </div>
+                                        <div className = "portalStatsBox">
+                                            <h3>Team Score</h3>
+                                            <p>{userRankData.score}</p>
+                                        </div>
 
-                                    <div className = "portalStatsBox">
-                                        <h3>Ranking</h3>
-                                        <p>{userRankData.rank}</p>
-                                    </div>
+                                        <div className = "portalStatsBox">
+                                            <h3>Ranking</h3>
+                                            <p>{userRankData.rank}</p>
+                                        </div>
 
-                                </section>
+                                    </section>
                                 }
                             </>
                          )}

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -10,6 +10,7 @@ import {
     createTeam,
     getCompetitionUser,
     getTeams,
+    leaveTeam
 } from '../../../actions/teams/utils';
 import TeamCard from '../../../components/TeamCard/index';
 import './index.less';
@@ -193,6 +194,16 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [newTeamName, setNewTeamName] = useState<string>("");
     const [isInviteModalVisible, setIsInviteModalVisible] = useState<boolean>(false);
+    const [isLeaveModalVisible, setIsLeaveModalVisible] = useState<boolean>(false);
+
+    // Leave button modal
+    const showLeaveModal = () => {
+        setIsLeaveModalVisible(true);
+    };
+
+    const handleLeaveModalClose = () => {
+        setIsLeaveModalVisible(false);
+    };
 
     // Invite button modal
     const showInviteModal = () => {
@@ -222,7 +233,7 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
             }
         },
         onDrop(e) {
-          console.log('Dropped files', e.dataTransfer.files);
+            console.log('Dropped files', e.dataTransfer.files);
         },
     };
 
@@ -231,20 +242,20 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
         useEffect(() => {
             // Generate avatar based on username using DiceBear
             const svg = createAvatar(botttsNeutral, {
-              seed: username,
-              radius: 50,
-              backgroundType: ["gradientLinear"]
+                seed: username,
+                radius: 50,
+                backgroundType: ["gradientLinear"]
             });
-        
+
             // Convert the SVG string to a data URL
             const dataUrl = `data:image/svg+xml;base64,${btoa(svg.toString())}`;
-        
+
             // Set the avatar URL
             setAvatarUrl(dataUrl);
         }, [username]);
         return (
             <img
-                src={avatarUrl} 
+                src={avatarUrl}
                 style={
                     {
                         width: '4rem',
@@ -252,7 +263,7 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
                         marginRight: '0.75rem'
                     }
                 }
-                alt={`Avatar for ${username}`} 
+                alt={`Avatar for ${username}`}
             />
         );
     }
@@ -275,6 +286,17 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
                 }}>
             </div>
         )
+    }
+
+    const handleLeaveTeam = () => {
+        leaveTeam(compUser.competitionName, compUser.username, compUser.competitionTeam.teamName).then((res) => {
+            message.success('Successfully left team.');
+            handleLeaveModalClose();
+            fetchTeamsCallback();
+        })
+            .catch((error) => (
+                message.error(error)
+            ));
     }
 
     const handleClick = () => {
@@ -325,8 +347,20 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
                 <section>
                     <div id="teamMainContent">
                         <div id="teamHeader">
-                            {generateTeamPicture()}
-                            <h3>{compUser.competitionTeam.teamName}</h3>
+                            <div>{generateTeamPicture()}</div>
+                            <div id="teamNameWrapper">
+                                <h3>{compUser.competitionTeam.teamName}</h3>
+                                <Button size="large" onClick={showLeaveModal}>Leave</Button>
+                                <Modal
+                                    title="Are you sure you want to leave this team?"
+                                    okText="Yes"
+                                    cancelText="No"
+                                    open={isLeaveModalVisible}
+                                    onOk={handleLeaveTeam}
+                                    onCancel={handleLeaveModalClose}
+                                >
+                                </Modal>
+                            </div>
                         </div>
 
                         <div id="teamScoreOverview">
@@ -348,30 +382,30 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
                             </div>
                         </div>
                         <h3 className="mainHeader">Upload Submission</h3>
-                        
+
                         <form>
                             <Dragger height={150} {...uploadProps}>
                                 <p className="antUploadDragIcon">
-                                <InboxOutlined />
+                                    <InboxOutlined />
                                 </p>
                                 <p className="antUploadText">Click or drag file to this area to upload</p>
                             </Dragger>
                             <Button
                                 htmlType="submit"
                                 className="submitButton"
-                                >
+                            >
                                 Submit
                             </Button>
                         </form>
-                        
+
                         <h3 className="mainHeader">Submission Log</h3>
                     </div>
 
                     {/* <Affix style={{ position: 'absolute', right: 0, top: 10,}} offsetTop={20}> */}
                     <div id="teamAffix">
                         <div id="teamMembersHeader">
-                            <h3 className="heading">Team Members</h3>
-                            <Button size = "large" id="inviteButton" onClick={showInviteModal}>Invite</Button>
+                            <h3 className="heading">Members</h3>
+                            <Button size="large" id="inviteButton" onClick={showInviteModal}>Invite</Button>
                             <Modal cancelButtonProps={{ style: { display: 'none' } }} title="Invite friends to your team" open={isInviteModalVisible} onOk={handleInviteModalClose}>
                                 <p>Share your Invite Code to your friend. Make sure to tell them your team name as well!</p>
                                 {/* TODO: For some reason, I couldn't get the CSS to show up when I put it in the CSS file */}

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -17,9 +17,14 @@ import { PaginationPosition, PaginationAlign } from "antd/es/pagination/Paginati
 import { CompetitionData, getLeaderboard, getMetaData, getRanks, registerCompetitionUser } from "../../../actions/competition";
 import { genColor } from "../../../utils/colors";
 import { IoHelp } from "react-icons/io5";
+import { BsPatchCheckFill } from "react-icons/bs";
+import { FaCheck, FaStar } from "react-icons/fa";
+import { GrScorecard } from "react-icons/gr";
+
 import Table, { ColumnsType } from "antd/es/table";
 import MainFooter from "../../../components/MainFooter";
 import { AxiosResponse } from "axios";
+import { BiStats } from "react-icons/bi";
 
 const { Content } = Layout;
 
@@ -595,18 +600,30 @@ function CompetitionPortalPage ()  {
                                 : 
                                     <section id = "portalStatsRow">
                                         <div className = "portalStatsBox">
-                                            <p>Your Total Submissions</p>
+                                            <span>
+                                                <FaCheck size = {20} style = {{padding: "6px", borderRadius: "8px", color: "blue", background: "lightblue", marginRight: "1rem"}}/>
+                                                <p>Your Submissions</p>
+                                            </span>
+
+                                            <p className = "stat">0</p>
+                                            
                                         </div>
 
                                         <div className = "portalStatsBox">
-                                            <p>Best Score</p>
-                                        
-                                            <p>{userRankData.score}</p>
+                                            <span>
+                                                <BiStats size = {24} style = {{padding: "4px", borderRadius: "8px", color: "green", background: "lightgreen", marginRight: "1rem"}}/>
+                                                <p>Best Score</p>
+                                            </span>
+                                            
+                                            <p className = "stat">{userRankData.score}</p>
                                         </div>
 
                                         <div className = "portalStatsBox">
-                                            <p>Ranking</p>
-                                            <p>{userRankData.rank}</p>
+                                            <span>
+                                                <FaStar size = {20} style = {{padding: "6px", borderRadius: "8px", color: "red", background: "pink",  marginRight: "1rem"}}/>
+                                                <p>Ranking</p>
+                                            </span>
+                                            <p className = "stat">{userRankData.rank}</p>
                                         </div>
 
                                         <div className = "portalStatsBox">

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -86,7 +86,7 @@ const FindTeamsTab = (
                 size="large"
                 style={{ width: "100%" }}
             >
-                <Input prefix={<IoSearch size = {20} style = {{marginRight: "0.5rem", color: "lightgrey"}} />}  size="large" placeholder="Look up a team name"  />
+                <Input allowClear bordered ={false} prefix={<IoSearch size = {20} style = {{marginRight: "0.5rem", color: "lightgrey"}} />}  size="large" placeholder="Look up a team name"  />
             </AutoComplete>
 
             {/** List to preview all the teams based on the user's query */}

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -1,7 +1,8 @@
 import React, { useContext, useEffect, useState } from "react";
 import { Affix, AutoComplete, Statistic, Drawer, List, Skeleton, Tabs, Tooltip, message, Empty } from "antd";
-import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
-import { Layout, Button, Input, Modal } from 'antd';
+import { ArrowDownOutlined, ArrowUpOutlined, PlusOutlined, InboxOutlined } from '@ant-design/icons';
+import { Form, Layout, Button, Input, Modal, Upload } from 'antd';
+import type { UploadProps } from 'antd';
 import UserContext, { User } from "../../../UserContext";
 import { useHistory } from 'react-router-dom';
 import {
@@ -9,7 +10,7 @@ import {
     createTeam,
     getCompetitionUser,
     getTeams,
-  } from '../../../actions/teams/utils';
+} from '../../../actions/teams/utils';
 import TeamCard from '../../../components/TeamCard/index';
 import './index.less';
 import path from 'path';
@@ -31,9 +32,9 @@ const { Content } = Layout;
 
 
 const FindTeamsTab = (
-    { data, user, compUser, registered, fetchTeams, updateRankings }: 
-    { data: Object[], user: User, compUser: any, registered: Boolean, fetchTeams: () => void, updateRankings: () => void }
-)  => {
+    { data, user, compUser, registered, fetchTeams, updateRankings }:
+        { data: Object[], user: User, compUser: any, registered: Boolean, fetchTeams: () => void, updateRankings: () => void }
+) => {
 
     // constants to align the pagination options for the teams list
     const [position] = useState<PaginationPosition>('bottom');
@@ -44,7 +45,7 @@ const FindTeamsTab = (
 
     // Initialize the teams data once that data defined
     useEffect(() => {
-        if(data) {
+        if (data) {
             setOptions(data);
         }
     }, [data, registered])
@@ -52,7 +53,7 @@ const FindTeamsTab = (
     const handleSearch = (value: string) => {
         // Reset options back to the original data if the value is an empty string
         if (value === "") {
-          setOptions(data);
+            setOptions(data);
         }
     }
 
@@ -66,101 +67,101 @@ const FindTeamsTab = (
     }
 
     return (
-      <Content id="findTeamsContainer">
-        <AutoComplete
-            id = "teamSearchBar"
-            onSearch={(text) => handleSearch(text)}
-            onSelect = {handleSelect}
+        <Content id="findTeamsContainer">
+            <AutoComplete
+                id="teamSearchBar"
+                onSearch={(text) => handleSearch(text)}
+                onSelect={handleSelect}
 
-            // list of all possible options for dropdown
-            options={options.map((item: any) => ({ value: item.teamName }))}
+                // list of all possible options for dropdown
+                options={options.map((item: any) => ({ value: item.teamName }))}
 
-            // filterOption to handle filtered dropdown items 
-            filterOption = {(inputValue, option) => 
-                option!.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
-            }
-            size="large"
-            style = {{width: "100%"}}
-        >
-            <Input size="large" placeholder="Look up a team name"/>
-        </AutoComplete>
+                // filterOption to handle filtered dropdown items 
+                filterOption={(inputValue, option) =>
+                    option!.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
+                }
+                size="large"
+                style={{ width: "100%" }}
+            >
+                <Input size="large" placeholder="Look up a team name" />
+            </AutoComplete>
 
-        {/** List to preview all the teams based on the user's query */}
-        <List
-            split = {false}
-            pagination={{ position, align, pageSize: 6}}
-            dataSource={options}
-            renderItem={(team: any) => (
-            <List.Item key = {team.competitionName}>
-                {<TeamCard team = {team} user = {user} compUser = {compUser} fetchTeamCallback = {fetchTeams} updateRankings = {updateRankings}/>}
-            </List.Item>
-            )}
-        />
+            {/** List to preview all the teams based on the user's query */}
+            <List
+                split={false}
+                pagination={{ position, align, pageSize: 6 }}
+                dataSource={options}
+                renderItem={(team: any) => (
+                    <List.Item key={team.competitionName}>
+                        {<TeamCard team={team} user={user} compUser={compUser} fetchTeamCallback={fetchTeams} updateRankings={updateRankings} />}
+                    </List.Item>
+                )}
+            />
 
-      </Content>
+        </Content>
     );
 };
 
 const LeaderBoardTab = (
-    {rankData, lastRefresh, updateRankingsCallback, isLoading}: 
-    {   
-        rankData: any,
-        lastRefresh: Date | null, 
-        updateRankingsCallback: () => void, 
-        isLoading: boolean
-    }
+    { rankData, lastRefresh, updateRankingsCallback, isLoading }:
+        {
+            rankData: any,
+            lastRefresh: Date | null,
+            updateRankingsCallback: () => void,
+            isLoading: boolean
+        }
 ) => {
     const columns: ColumnsType<CompetitionData> = [
         {
-          title: 'Rank',
-          dataIndex: 'rank',
-          sorter: (a, b) => b.score - a.score,
-          defaultSortOrder: 'ascend',
+            title: 'Rank',
+            dataIndex: 'rank',
+            sorter: (a, b) => b.score - a.score,
+            defaultSortOrder: 'ascend',
         },
         {
-          title: 'Team',
-          dataIndex: 'team',
-          sorter: (a, b) => a.team.length - b.team.length,
-          render(value, record, index) {
-            const color1 = genColor(record.team);
-            const color2 = genColor(`${record.team}_additional_seed`);
+            title: 'Team',
+            dataIndex: 'team',
+            sorter: (a, b) => a.team.length - b.team.length,
+            render(value, record, index) {
+                const color1 = genColor(record.team);
+                const color2 = genColor(`${record.team}_additional_seed`);
 
-            return (
-              <span>
-                <div
-                  style={{
-                    display: 'inline-block',
-                    verticalAlign: 'middle',
-                    borderRadius: '50%',
-                    width: '2rem',
-                    height: '2rem',
-                    background: `linear-gradient(30deg, ${color1}, ${color2})`,
-                    marginRight: '0.75rem',
-                  }}
-                ></div>
-                {value.length > 28 ? (
-                  <span>{value.substring(0, 28)}...</span>
-                ) : (
-                  <span>{value.substring(0, 28)}</span>
-                )}
-              </span>
-            );
-          },
+                return (
+                    <span>
+                        <div
+                            style={{
+                                display: 'inline-block',
+                                verticalAlign: 'middle',
+                                borderRadius: '50%',
+                                width: '2rem',
+                                height: '2rem',
+                                background: `linear-gradient(30deg, ${color1}, ${color2})`,
+                                marginRight: '0.75rem',
+                            }}
+                        ></div>
+                        {value.length > 28 ? (
+                            <span>{value.substring(0, 28)}...</span>
+                        ) : (
+                            <span>{value.substring(0, 28)}</span>
+                        )}
+                    </span>
+                );
+            },
         },
         {
-          title: 'Score',
-          dataIndex: 'score',
-          sorter: (a, b) => a.score - b.score,
+            title: 'Score',
+            dataIndex: 'score',
+            sorter: (a, b) => a.score - b.score,
         },
     ];
 
 
-    
+
     return (
-      <Content id="leaderBoardContainer">
+        <Content id="leaderBoardContainer">
             <section>
 
-                <p id = "lastRefreshedText">
+                <p id="lastRefreshedText">
                     Last refreshed{': '}
                     {lastRefresh ? lastRefresh.toLocaleString() : ''}
                 </p>
@@ -170,12 +171,12 @@ const LeaderBoardTab = (
                     onClick={() => {
                         updateRankingsCallback();
                     }}
-                    >
-                        Refresh
-                    </Button> 
+                >
+                    Refresh
+                </Button>
             </section>
             <Table loading={isLoading} columns={columns} dataSource={rankData} />
-      </Content>
+        </Content>
     );
 };
 
@@ -184,15 +185,33 @@ const LeaderBoardTab = (
 
 
 
-const MyTeamTab = ( { compUser, fetchTeamsCallback}: {compUser: any, fetchTeamsCallback: () => void}) => {
+const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeamsCallback: () => void }) => {
 
-    const [isLoading, setIsLoading] =  useState<boolean>(false);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
     const [newTeamName, setNewTeamName] = useState("");
-    
-    useEffect(() => {
 
-    }, []);
-
+    // Upload submission
+    const { Dragger } = Upload;
+    const uploadProps: UploadProps = {
+        name: 'file',
+        multiple: false,
+        // TODO: replace placeholder link with actual file uploading logic
+        action: 'https://run.mocky.io/v3/435e224c-44fb-4773-9faf-380c5e6a2188',
+        onChange(info) {
+          const { status } = info.file;
+          if (status !== 'uploading') {
+            console.log(info.file, info.fileList);
+          }
+          if (status === 'done') {
+            message.success(`${info.file.name} file uploaded successfully.`);
+          } else if (status === 'error') {
+            message.error(`${info.file.name} file upload failed.`);
+          }
+        },
+        onDrop(e) {
+          console.log('Dropped files', e.dataTransfer.files);
+        },
+      };
 
     const generateTeamPicture = () => {
 
@@ -200,23 +219,23 @@ const MyTeamTab = ( { compUser, fetchTeamsCallback}: {compUser: any, fetchTeamsC
         const color2 = genColor(`${compUser.competitionTeam.teamName}_additional_seed`);
 
         return (
-            <div 
-            style={{
-                display: 'inline-block',
-                verticalAlign: 'middle',
-                borderRadius: '50%',
-                width: '4rem',
-                height:'4rem',
-                background: `linear-gradient(30deg, ${color1}, ${color2})`,
-                marginRight: '0.75rem',
-              }}>
+            <div
+                style={{
+                    display: 'inline-block',
+                    verticalAlign: 'middle',
+                    borderRadius: '50%',
+                    width: '4rem',
+                    height: '4rem',
+                    background: `linear-gradient(30deg, ${color1}, ${color2})`,
+                    marginRight: '0.75rem',
+                }}>
             </div>
         )
     }
 
     const handleClick = () => {
 
-        if(newTeamName.length == 0) {
+        if (newTeamName.length == 0) {
             message.info('Name cannot be empty');
             return;
         }
@@ -226,86 +245,93 @@ const MyTeamTab = ( { compUser, fetchTeamsCallback}: {compUser: any, fetchTeamsC
             message.success('Successfully made a new team!');
             fetchTeamsCallback();
             console.log(compUser)
-        
+
         })
-        .catch((error) => {
-            message.error(error.message);
-        });
+            .catch((error) => {
+                message.error(error.message);
+            });
 
         setIsLoading(false);
     }
 
     return (
-      <Content id="myTeamContainer" >
-        {compUser.competitionTeam == null && (
+        <Content id="myTeamContainer" >
+            {compUser.competitionTeam == null && (
 
-            <section>
-                <Input 
-                    id = "teamNameInput" 
-                    placeholder="New Team Name" 
-                    size = "large"
-                    onChange={(e) => setNewTeamName(e.target.value)}
+                <section>
+                    <Input
+                        id="teamNameInput"
+                        placeholder="New Team Name"
+                        size="large"
+                        onChange={(e) => setNewTeamName(e.target.value)}
                     >
-                </Input><br/>
-                <Button 
-                    type = "primary" 
-                    size = "large" id = "makeTeamButton" 
-                    loading = {isLoading} 
-                    onClick={handleClick} 
-                >
-                    Make Team
-                </Button>
-            </section>
-            
+                    </Input><br />
+                    <Button
+                        type="primary"
+                        size="large" id="makeTeamButton"
+                        loading={isLoading}
+                        onClick={handleClick}
+                    >
+                        Make Team
+                    </Button>
+                </section>
+            )}
 
-        ) }
-
-        {compUser.competitionTeam !== null && (
-            <section>
-                <div id = "teamMainContent">
-                        <div id = "teamHeader">
+            {compUser.competitionTeam !== null && (
+                <section>
+                    <div id="teamMainContent">
+                        <div id="teamHeader">
                             {generateTeamPicture()}
-                            <div>
-                                <h3>{compUser.competitionTeam.teamName}</h3>
-                                <p>nth place</p>
+                            <h3>{compUser.competitionTeam.teamName}</h3>
+                        </div>
+
+                        <div id="teamScoreOverview">
+                            <p className="statHeader">score</p>
+                            <p className="score">0</p>
+                            <div id="teamScoreSpecifics">
+                                <div>
+                                    <p className="statHeader">Sigma</p>
+                                    <p className="stat">0.78</p>
+                                </div>
+                                <div>
+                                    <p className="statHeader">Mu</p>
+                                    <p className="stat">0.78</p>
+                                </div>
+                                <div>
+                                    <p className="statHeader">MSE</p>
+                                    <p className="stat">0.78</p>
+                                </div>
                             </div>
                         </div>
+                        <h3 className="mainHeader">Upload Submission</h3>
                         
-                        <div id = "teamScoreOverview">
-                            <p className = "statHeader">score</p>
-                            <p className = "score">0</p>
-                            <div id = "teamScoreSpecifics">
-                                <div>
-                                    <p className = "statHeader">Sigma</p>
-                                    <p className = "stat">0.78</p>
-                                </div>
-                                <div>
-                                    <p className = "statHeader">Mu</p>
-                                    <p className = "stat">0.78</p>
-                                </div>
-                                <div>
-                                    <p className = "statHeader">MSE</p>
-                                    <p className = "stat">0.78</p>
-                                </div>
-                            </div>
-                        </div>
                         <form>
-                            <h3 className="mainHeader">Upload File</h3>
-                            <input type="file" />
-                            <button type="submit">Upload</button>
+                            <Dragger height={150} {...uploadProps}>
+                                <p className="antUploadDragIcon">
+                                <InboxOutlined />
+                                </p>
+                                <p className="antUploadText">Click or drag file to this area to upload</p>
+                            </Dragger>
+                            <Button
+                                htmlType="submit"
+                                className="submitButton"
+                                >
+                                Submit
+                            </Button>
                         </form>
+                        
                         <h3 className="mainHeader">Submission Log</h3>
-                        {/* <p id = "teamDescription">fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds jdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj </p> */}
-                </div>
-                
-                {/* <Affix style={{ position: 'absolute', right: 0, top: 10,}} offsetTop={20}> */}
-                    <div id = "teamAffix">
-                        <div id = "teamMembersHeader">
-                            <h3 className= "heading">Team Members</h3>
-                            <Button id = "inviteButton">Invite</Button>
+
+                    </div>
+
+                    {/* <Affix style={{ position: 'absolute', right: 0, top: 10,}} offsetTop={20}> */}
+                    <div id="teamAffix">
+                        <div id="teamMembersHeader">
+                            <h3 className="heading">Team Members</h3>
+                            <Button id="inviteButton">Invite</Button>
                         </div>
                         {compUser.competitionTeam.teamMembers.map((member: string, index: number) => (
-                            <div id = "teamMember" key={index}>
+                            <div id="teamMember" key={index}>
                                 {generateTeamPicture()}
                                 <div>
                                     <p className="teamMemberName">{member}</p>
@@ -314,19 +340,19 @@ const MyTeamTab = ( { compUser, fetchTeamsCallback}: {compUser: any, fetchTeamsC
                             </div>
                         ))}
                     </div>
-                {/* </Affix> */}
-            </section>
-        )}
-        
-      </Content>
+                    {/* </Affix> */}
+                </section>
+            )}
+
+        </Content>
     );
-  };
+};
 
-  
 
-function CompetitionPortalPage ()  {
 
-    const competitionName  = "TestCompetition2";
+function CompetitionPortalPage() {
+
+    const competitionName = "TestCompetition2";
     const history = useHistory();
 
     // User profile data
@@ -348,10 +374,12 @@ function CompetitionPortalPage ()  {
     const [rankingsData, setRankingsData] = useState<CompetitionData[]>([]);
 
     // Rank data for user's current team
-    const [userRankData, setUserRankData] = useState<CompetitionData>({rank: 0,
+    const [userRankData, setUserRankData] = useState<CompetitionData>({
+        rank: 0,
         team: "",
         score: 0,
-        submitHistory: []}
+        submitHistory: []
+    }
     );
 
     // Loading states for leaderboard data fetching status
@@ -373,8 +401,8 @@ function CompetitionPortalPage ()  {
     } | null>(null);
 
 
-     // Modal callback to show modal to register user for competition
-     const showModal = () => {
+    // Modal callback to show modal to register user for competition
+    const showModal = () => {
         setIsModalOpen(true);
     };
     const handleCancel = () => {
@@ -389,33 +417,33 @@ function CompetitionPortalPage ()  {
      * any other data.
      **/
     const fetchTeams = () => {
-          
-        getCompetitionUser(competitionName, user.username).then((res) =>  {
-            if(!res.data.registered) {
+
+        getCompetitionUser(competitionName, user.username).then((res) => {
+            if (!res.data.registered) {
                 message.info("you are not registered!");
 
                 // Expose the register modal. When user registers, the page will reload
                 showModal();
             }
-            else {  
+            else {
                 // update the compeition user state
                 setCompUser(res.data);
 
                 // fetch all the teams
                 getTeams(competitionName).then(res => {
-                    if(res.data) {
+                    if (res.data) {
                         setAllTeams(Array.from(res.data))
                     }
                 })
-                .catch(error => {
-                    console.log(error);
-                });
+                    .catch(error => {
+                        console.log(error);
+                    });
             }
         })
     }
 
     // Function to get compeitition meta data
-    const getCompMetaData = async () =>  {
+    const getCompMetaData = async () => {
 
         getMetaData(competitionName).then((res) => {
             setMeta(res.data);
@@ -431,31 +459,31 @@ function CompetitionPortalPage ()  {
 
         getLeaderboard(competitionName).then((res) => {
             console.log(res.data)
-          
+
             let newData = res.data.sort((a: any, b: any) => b.bestScore - a.bestScore) // Sort by bestScore in descending order
-            .map((d: any, index: number) => {
+                .map((d: any, index: number) => {
 
-                if(teamInfo != null) {
-                    if(d.teamName === teamInfo.teamName) {
-                        setUserRankData( {
-                            rank: index + 1,
-                            team: d.teamName,
-                            score: d.bestScore,
-                            submitHistory: d.submitHistory,
-                        });
-    
-                        console.log("user rank data: ", userRankData);
+                    if (teamInfo != null) {
+                        if (d.teamName === teamInfo.teamName) {
+                            setUserRankData({
+                                rank: index + 1,
+                                team: d.teamName,
+                                score: d.bestScore,
+                                submitHistory: d.submitHistory,
+                            });
+
+                            console.log("user rank data: ", userRankData);
+                        }
                     }
-                }
-            
 
-                return {
-                    rank: index + 1,
-                    team: d.teamName,
-                    score: d.bestScore,
-                    submitHistory: d.submitHistory,
-                };
-            });
+
+                    return {
+                        rank: index + 1,
+                        team: d.teamName,
+                        score: d.bestScore,
+                        submitHistory: d.submitHistory,
+                    };
+                });
 
             setLastRefresh(new Date());
             setRankingsData(newData);
@@ -463,7 +491,7 @@ function CompetitionPortalPage ()  {
             setIsLoadingTeamInfo(false);
 
         });
-      };
+    };
 
 
     /**
@@ -472,8 +500,8 @@ function CompetitionPortalPage ()  {
      */
     useEffect(() => {
         if (!user.loggedIn) {
-          message.info('You need to login to upload predictions and participate');
-          history.replace(path.join(window.location.pathname, '../../../login'));
+            message.info('You need to login to upload predictions and participate');
+            history.replace(path.join(window.location.pathname, '../../../login'));
         }
 
         else {
@@ -483,7 +511,7 @@ function CompetitionPortalPage ()  {
             fetchTeams();
             getCompMetaData();
         }
-        
+
     }, []);
 
 
@@ -496,7 +524,7 @@ function CompetitionPortalPage ()  {
     const updateTeamInformation = () => {
         getTeamInfo(competitionName, compUser.competitionTeam.teamName).then((res) => {
             setTeamInfo(res.data);
-        })  
+        })
     }
 
     /**
@@ -511,8 +539,8 @@ function CompetitionPortalPage ()  {
         setIsLoadingTeamInfo(true);
 
         // If comp user is in a team, grab the team information
-        if(Object.keys(compUser).length !== 0){
-            if(compUser.competitionTeam != null){ 
+        if (Object.keys(compUser).length !== 0) {
+            if (compUser.competitionTeam != null) {
                 console.log(compUser)
                 updateTeamInformation();
             }
@@ -525,7 +553,7 @@ function CompetitionPortalPage ()  {
             setTeamInfo(null)
             setIsLoadingTeamInfo(false);
         }
-            
+
     }, [compUser])
 
 
@@ -537,14 +565,14 @@ function CompetitionPortalPage ()  {
     useEffect(() => {
         updateRankings();
 
-        if(teamInfo !== null) {
+        if (teamInfo !== null) {
             console.log("setting bar chart")
             // update the score history chart here
-            if(teamInfo.scoreHistory) {
+            if (teamInfo.scoreHistory) {
                 let scores = teamInfo.scoreHistory.slice(-7);
                 scores = scores.map(Number);
                 setBarHeights(scores);
-    
+
                 // Find the maximum score
                 const maxScore = Math.max(...scores);
 
@@ -553,26 +581,26 @@ function CompetitionPortalPage ()  {
                 const diff = lastTwo[1] - lastTwo[0];
                 const percent = diff / lastTwo[0];
                 setScoreHistoryPercentage(percent);
-    
-                 // Set your desired maximum height for the bars
+
+                // Set your desired maximum height for the bars
                 const maxBarHeight = 92;
-    
+
                 // Calculate the scaling factor
                 const scalingFactor = maxBarHeight / maxScore;
                 setScale(scalingFactor);
                 console.log(teamInfo.scoreHistory);
 
             }
-         
+
         }
-                
+
     }, [teamInfo]);
 
 
 
     // When user registers for compeititons, allow access to portal
     const onSubmit = () => {
-        registerCompetitionUser(competitionName, user.username).then((res) =>  {
+        registerCompetitionUser(competitionName, user.username).then((res) => {
             if (res.data.msg == "Success") {
                 window.location.reload();
                 setIsRegistered(true);
@@ -589,21 +617,21 @@ function CompetitionPortalPage ()  {
 
             {/** Register Modal */}
             <Modal
-                 className="registerUserModal"
-                 width={800}
-                 centered
-                 closeIcon = {false}
-                 open={isModalOpen}
-                 maskClosable = {false}
-                 onCancel={handleCancel}
-                 title={<h3 style={{ fontWeight: '700' }}>Register</h3>}
-                 footer = {null}
-             >
+                className="registerUserModal"
+                width={800}
+                centered
+                closeIcon={false}
+                open={isModalOpen}
+                maskClosable={false}
+                onCancel={handleCancel}
+                title={<h3 style={{ fontWeight: '700' }}>Register</h3>}
+                footer={null}
+            >
                 <p>
-                    Looks like we don't have you registered for {competitionName} yet. Click register below to get started. The page will 
+                    Looks like we don't have you registered for {competitionName} yet. Click register below to get started. The page will
                     reload once we confirm your registration. Otherwise, feel free to leave this page.
                 </p>
-                <Button onClick = {onSubmit} >
+                <Button onClick={onSubmit} >
                     Register
                 </Button>
 
@@ -612,122 +640,122 @@ function CompetitionPortalPage ()  {
                         history.push(path.join(history.location.pathname, '../competitions'));
                     }}
                 >Go Back</Button>
-            </Modal> 
+            </Modal>
 
 
             <Content className="CompetitionPortalPage">
-                <Content id = "portalHeader">
+                <Content id="portalHeader">
                     <section>
                         <span>
                             <h1 className="title2">Hello, {user.username}</h1>
                             <Tooltip title="Help">
-                                <Button icon = {<IoHelp size = {20}/>}></Button>
+                                <Button icon={<IoHelp size={20} />}></Button>
 
                             </Tooltip>
 
                         </span>
-                        <div id = "portalBanner">
+                        <div id="portalBanner">
                             <p>Welcome the the AI Portal for {competitionName}</p>
                         </div>
-                            
+
                     </section>
 
-            
-                    <section id = "portalStatsContent">
 
-                         {isLoadingTeamInfo ? (
+                    <section id="portalStatsContent">
+
+                        {isLoadingTeamInfo ? (
                             <Skeleton active></Skeleton>
-                         ):
-                          (  <>
-                                {compUser.competitionTeam == null ? 
-                                    <section id = "noTeamMessage">
+                        ) :
+                            (<>
+                                {compUser.competitionTeam == null ?
+                                    <section id="noTeamMessage">
                                         <p>
-                                        Uh oh! You’re not in a team yet. Either make your own team or ask your friends to share their invite code, 
-                                        then navigate to Find Teams below to join their group!
+                                            Uh oh! You’re not in a team yet. Either make your own team or ask your friends to share their invite code,
+                                            then navigate to Find Teams below to join their group!
                                         </p>
                                     </section>
-                                    
-                                : 
-                                    <section id = "portalStatsRow">
-                                        <div className = "portalStatsBox">
+
+                                    :
+                                    <section id="portalStatsRow">
+                                        <div className="portalStatsBox">
                                             <span>
-                                                <FaCheck size = {20} style = {{padding: "6px", borderRadius: "8px", color: "#ff6f6f", background: "pink", marginRight: "1rem"}}/>
+                                                <FaCheck size={20} style={{ padding: "6px", borderRadius: "8px", color: "#ff6f6f", background: "pink", marginRight: "1rem" }} />
                                                 <p>Your Submissions</p>
                                             </span>
 
-                                            <p className = "stat">0</p>
-                                            
+                                            <p className="stat">0</p>
+
                                         </div>
 
-                                        <div className = "portalStatsBox">
+                                        <div className="portalStatsBox">
                                             <span>
-                                                <BiStats size = {24} style = {{padding: "4px", borderRadius: "8px", color: "#fe8019", background: "#FCC777", marginRight: "1rem"}}/>
+                                                <BiStats size={24} style={{ padding: "4px", borderRadius: "8px", color: "#fe8019", background: "#FCC777", marginRight: "1rem" }} />
                                                 <p>Best Score</p>
                                             </span>
-                                            
-                                            <p className = "stat">{userRankData.score}</p>
+
+                                            <p className="stat">{userRankData.score}</p>
                                         </div>
 
-                                        <div className = "portalStatsBox">
+                                        <div className="portalStatsBox">
                                             <span>
-                                                <FaStar size = {20} style = {{padding: "6px", borderRadius: "8px", color: "red", background: "pink",  marginRight: "1rem"}}/>
+                                                <FaStar size={20} style={{ padding: "6px", borderRadius: "8px", color: "red", background: "pink", marginRight: "1rem" }} />
                                                 <p>Ranking</p>
                                             </span>
-                                            <p className = "stat">{userRankData.rank}</p>
+                                            <p className="stat">{userRankData.rank}</p>
                                         </div>
 
-                                        <div className = "portalStatsBox">
+                                        <div className="portalStatsBox">
                                             <span>
                                                 <p>Score History</p>
-                                                {scoreHistoryPercentage  ? 
+                                                {scoreHistoryPercentage ?
                                                     <Statistic
                                                         value={Math.abs(scoreHistoryPercentage)}
                                                         precision={2}
-                                                        valueStyle={{ color: scoreHistoryPercentage < 0 ? '#cf1322' : '#3f8600', fontSize: "1.2rem", display:"inline" }}
-                                                        prefix={ scoreHistoryPercentage < 0 ?  <ArrowDownOutlined /> : <ArrowUpOutlined /> }
+                                                        valueStyle={{ color: scoreHistoryPercentage < 0 ? '#cf1322' : '#3f8600', fontSize: "1.2rem", display: "inline" }}
+                                                        prefix={scoreHistoryPercentage < 0 ? <ArrowDownOutlined /> : <ArrowUpOutlined />}
                                                         suffix="%"
                                                     />
                                                     :
-                                                   <></>
+                                                    <></>
                                                 }
                                             </span>
-                                            <div id = "scoreHistoryChart">
+                                            <div id="scoreHistoryChart">
                                                 {barHeights.length > 0 ?
                                                     <>
-                                                    {barHeights.map((height:number, index:any) => (
-                                                        <Tooltip title={height}>
+                                                        {barHeights.map((height: number, index: any) => (
+                                                            <Tooltip title={height}>
+                                                                <div
+                                                                    key={index}
+                                                                    className="scoreBar"
+                                                                    style={{ height: `${height * scale}px` }}
+                                                                ></div>
+
+                                                            </Tooltip>
+                                                        ))}
+                                                        {Array.from({ length: 7 - barHeights.length }, (index: any) => (
                                                             <div
                                                                 key={index}
                                                                 className="scoreBar"
-                                                                style={{ height: `${height * scale}px`}}
+                                                                style={{ height: `92px`, backgroundColor: "lightgrey" }}
                                                             ></div>
 
-                                                        </Tooltip>
-                                                    ))}
-                                                    {Array.from({ length: 7 - barHeights.length }, (index : any) => (
-                                                        <div
-                                                            key={index}
-                                                            className="scoreBar"
-                                                            style={{ height: `92px`, backgroundColor: "lightgrey"}}
-                                                        ></div>
-
-                                                    ))}
+                                                        ))}
                                                     </>
                                                     :
                                                     <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
                                                 }
                                             </div>
-            
+
                                         </div>
 
                                     </section>
                                 }
                             </>
-                         )}
+                            )}
                     </section>
                 </Content>
 
-                <Content id = "portalTabContent">
+                <Content id="portalTabContent">
                     <Tabs
                         size="small"
                         animated={true}
@@ -738,28 +766,28 @@ function CompetitionPortalPage ()  {
                                 {
                                     label: <p>Leaderboard</p>,
                                     key: '1',
-                                    children: <LeaderBoardTab 
-                                        rankData = {rankingsData}
-                                        lastRefresh = {lastRefresh}
-                                        updateRankingsCallback={updateRankings} 
-                                        isLoading={isLoadingLeaderBoard}/>
+                                    children: <LeaderBoardTab
+                                        rankData={rankingsData}
+                                        lastRefresh={lastRefresh}
+                                        updateRankingsCallback={updateRankings}
+                                        isLoading={isLoadingLeaderBoard} />
                                 },
                                 {
                                     label: <p>Find Teams</p>,
                                     key: '2',
-                                    children: <FindTeamsTab 
-                                        data = {allTeams} 
-                                        user = {user} 
+                                    children: <FindTeamsTab
+                                        data={allTeams}
+                                        user={user}
                                         compUser={compUser}
-                                        registered = {isRegistered} 
+                                        registered={isRegistered}
                                         fetchTeams={fetchTeams}
-                                        updateRankings={updateRankings}/>
+                                        updateRankings={updateRankings} />
                                 },
                                 {
                                     label: <p>My Team</p>,
                                     key: '3',
-                                    children: <MyTeamTab 
-                                        compUser={compUser} 
+                                    children: <MyTeamTab
+                                        compUser={compUser}
                                         fetchTeamsCallback={fetchTeams} />,
                                 },
                             ]

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -191,7 +191,17 @@ const LeaderBoardTab = (
 const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeamsCallback: () => void }) => {
 
     const [isLoading, setIsLoading] = useState<boolean>(false);
-    const [newTeamName, setNewTeamName] = useState("");
+    const [newTeamName, setNewTeamName] = useState<string>("");
+    const [isInviteModalVisible, setIsInviteModalVisible] = useState<boolean>(false);
+
+    // Invite button modal
+    const showInviteModal = () => {
+        setIsInviteModalVisible(true);
+    };
+
+    const handleInviteModalClose = () => {
+        setIsInviteModalVisible(false);
+    };
 
     // Upload submission
     const { Dragger } = Upload;
@@ -361,7 +371,17 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
                     <div id="teamAffix">
                         <div id="teamMembersHeader">
                             <h3 className="heading">Team Members</h3>
-                            <Button id="inviteButton">Invite</Button>
+                            <Button id="inviteButton" onClick={showInviteModal}>Invite</Button>
+                            <Modal cancelButtonProps={{ style: { display: 'none' } }} title="Invite friends to your team" open={isInviteModalVisible} onOk={handleInviteModalClose}>
+                                <p>Share your Invite Code to your friend. Make sure to tell them your team name as well!</p>
+                                {/* TODO: For some reason, I couldn't get the CSS to show up when I put it in the CSS file */}
+                                <h3 style={{
+                                    fontWeight: 'bold',
+                                    marginTop: '5px'
+                                }}>
+                                    {compUser.competitionTeam.joinCode}
+                                </h3>
+                            </Modal>
                         </div>
                         {compUser.competitionTeam.teamMembers.map((member: string, index: number) => (
                             <div id="teamMember" key={index}>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -42,25 +42,22 @@ const teamCard = (team: any): React.ReactNode => {
 
 const FindTeamsTab = (data: Array<Object>): React.ReactNode => {
 
+    // constants to align the pagination options for the teams list
     const [position] = useState<PaginationPosition>('bottom');
     const [align] = useState<PaginationAlign>('center');
-    const [searchTerm, setSearchTerm] = useState("");
 
     // dropdown options for search bar
     const [options, setOptions] = useState<Array<Object>>(data);
 
-    // data for the list
-
-
+    // Initialize the teams data once that data defined
     useEffect(() => {
         if(data) {
             setOptions(data);
         }
     }, [data])
 
-    const handleSearch = (value: string) => {
-        setSearchTerm(value);
 
+    const handleSearch = (value: string) => {
         // Reset options back to the original data if the value is an empty string
         if (value === "") {
           setOptions(data);
@@ -70,12 +67,11 @@ const FindTeamsTab = (data: Array<Object>): React.ReactNode => {
 
     const handleSelect = (value: string) => {
 
+        // filter the list items
         const filteredOptions = data.filter((item: any) =>
-            item.teamName.toLowerCase().includes(value.toLowerCase())
+            item.teamName.toUpperCase().includes(value.toUpperCase())
         );
-        
         setOptions(filteredOptions)
-
     }
 
     return (
@@ -84,17 +80,21 @@ const FindTeamsTab = (data: Array<Object>): React.ReactNode => {
             id = "teamSearchBar"
             onSearch={(text) => handleSearch(text)}
             onSelect = {handleSelect}
+
+            // list of all possible options for dropdown
             options={options.map((item: any) => ({ value: item.teamName }))}
+
+            // filterOption to handle filtered dropdown items 
             filterOption = {(inputValue, option) => 
-                option?.value.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1
+                option!.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
             }
             size = "large"
             style = {{width: "100%", fontSize: 1.4}}
         >
             <Input.Search size="large" placeholder="Look up a team name" enterButton />
-
         </AutoComplete>
 
+        {/** List to preview all the teams based on the user's query */}
         <List
             split = {false}
             pagination={{ position, align}}
@@ -115,7 +115,6 @@ const LeaderBoardTab = (): React.ReactNode => {
     return (
       <Content id="leaderBoardContainer" className = "portalTabContent">
             <h2>Leaderboard</h2>
-
       </Content>
     );
 };
@@ -165,8 +164,9 @@ function CompetitionPortalPage ()  {
         }
 
         else {
-            // Grab all the teams for the current competitions
-            // Note: I am using the test competition name from mongoDB
+            /* Grab all the teams for the current competitions
+             * Note: I am using the test competition 2 name from mongoDB
+             */
             getTeams("TestCompetition2").then(res => {
                 if(res.data) {
                     setAllTeams(Array.from(res.data))
@@ -183,7 +183,6 @@ function CompetitionPortalPage ()  {
     
     return (
         <DefaultLayout>
-
             <Content className="CompetitionPortalPage">
                 <Content id = "portalHeader">
                     <section>
@@ -201,6 +200,7 @@ function CompetitionPortalPage ()  {
                 </Content>
 
             
+
                 <Content id = "portalTabContent">
                     <Tabs
                         size="small"
@@ -227,9 +227,7 @@ function CompetitionPortalPage ()  {
                         }
                     ></Tabs>
                 </Content>
-
             </Content>
-
         </DefaultLayout>
     );
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -1,22 +1,87 @@
 import React, { useContext, useEffect } from "react";
-import { message } from "antd";
+import { List, Tabs, message } from "antd";
 import { Layout, Space, Button } from 'antd';
 import UserContext from "../../../UserContext";
 import { useHistory } from 'react-router-dom';
+import {
+    getTeamInfo,
+    createTeam,
+    getCompetitionUser,
+  } from '../../../actions/teams/utils';
+
 import './index.less';
+import path from 'path';
+
 import DefaultLayout from "../../../components/layouts/default";
 
 const { Content } = Layout;
 
 
+
+const FindTeamsTab = (): React.ReactNode => {
+    return (
+      <Content id="findTeamsContainer" className = "portalTabContent">
+        <h2>Find Teams</h2>
+
+      </Content>
+    );
+  };
+
+  
+const LeaderBoardTab = (): React.ReactNode => {
+    return (
+      <Content id="leaderBoardContainer" className = "portalTabContent">
+            <h2>Leaderboard</h2>
+
+      </Content>
+    );
+  };
+
+
+  const MyTeamTab = (): React.ReactNode => {
+    return (
+      <Content id="myTeamContainer" className = "portalTabContent">
+        <h2>My Team</h2>
+      </Content>
+    );
+  };
+
+  
+
 function CompetitionPortalPage ()  {
     const history = useHistory();
     const { user } = useContext(UserContext);
 
+    const tabItems= [
+        {
+            label: <p>Leaderboard</p>,
+            key: '1',
+            children: LeaderBoardTab(),
+        },
+        {
+            label: <p>Find Teams</p>,
+            key: '2',
+            children: FindTeamsTab(),
+        },
+        {
+            label: <p>My Team</p>,
+            key: '3',
+            children: MyTeamTab(),
+        }
+        ];
+
     useEffect(() => {
         if (!user.loggedIn) {
           message.info('You need to login to upload predictions and participate');
-        //   history.replace(path.join(window.location.pathname, '../../../login'));
+          history.replace(path.join(window.location.pathname, '../../../login'));
+        }
+      }, []);
+
+
+      useEffect(() => {
+        if (!user.loggedIn) {
+          message.info('You need to login to upload predictions and participate');
+          history.replace(path.join(window.location.pathname, '../../../login'));
         }
       }, []);
     
@@ -25,10 +90,30 @@ function CompetitionPortalPage ()  {
 
             <Content className="CompetitionPortalPage">
                 <Content id = "portalHeader">
-                <div >
-                    <h1 className="title2">Hello, {user.username}</h1>
-                    <h4>Welcome the the AI Portal</h4>
-                </div>
+                    <section>
+                        <h1 className="title2">Hello, {user.username}</h1>
+                        <h4>Welcome the the AI Portal</h4>
+                    </section>
+
+                    <section id = "portalStatsContent">
+                        <p id = "noTeamMessage">Uh oh! You’re not in a team yet. Ask your friends to share their invite code, then navigate to Find Teams below to join their group!</p>
+
+                    </section>
+                </Content>
+
+                
+
+    
+            
+
+                <Content id = "portalTabContent">
+                    {/* If the user is not part of a team yet, then */}
+                    <Tabs
+                        size="small"
+                        animated={true}
+                        tabPosition="top"
+                        items={tabItems}
+                    ></Tabs>
                 </Content>
 
             </Content>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -86,7 +86,7 @@ const FindTeamsTab = (data: Array<Object>): React.ReactNode => {
             onSelect = {handleSelect}
             options={options.map((item: any) => ({ value: item.teamName }))}
             filterOption = {(inputValue, option) => 
-                option?.value.toLowerCase().includes(inputValue.toLowerCase())
+                option?.value.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1
             }
             size = "large"
             style = {{width: "100%", fontSize: 1.4}}

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -134,6 +134,9 @@ const LeaderBoardTab = ( ) => {
             message.error(error.message);
         });
 
+        setIsLoading(false);
+
+
     }
 
     return (
@@ -180,6 +183,8 @@ function CompetitionPortalPage ()  {
     const [activeTab, setActiveTab] = useState('1'); // Set the default active tab key
     const [isRegistered, setIsRegistered] = useState<any>(false);
 
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
     const [isLoadingTeamInfo, setIsLoadingTeamInfo] = useState(false);
     const [teamInfo, setTeamInfo] = useState<any>({});
     const competitionName  = "TestCompetition2";
@@ -190,7 +195,6 @@ function CompetitionPortalPage ()  {
         setActiveTab(key);
     }
 
-    const [isModalOpen, setIsModalOpen] = useState(false);
 
      // Modal props
      const showModal = () => {
@@ -221,7 +225,6 @@ function CompetitionPortalPage ()  {
                 .catch(error => {
                     console.log(error);
                 });
-
             }
         })
     }
@@ -240,19 +243,22 @@ function CompetitionPortalPage ()  {
 
     // only grab team info when user is in a team
     useEffect(() => {
-        if(Object.keys(compUser).length !== 0){
+        setIsLoadingTeamInfo(true);
 
+        if(Object.keys(compUser).length !== 0){
             if(compUser.competitionTeam != null){ 
                 console.log(compUser)
-                setIsLoadingTeamInfo(true);
                 getTeamInfo(competitionName, compUser.competitionTeam.teamName).then((res) => {
                     setTeamInfo(res.data);
-                    setIsLoadingTeamInfo(false);
 
                 })  
             }
+            setIsLoadingTeamInfo(false);
+
+
         }
-       
+        
+
     }, [compUser])
 
     
@@ -311,26 +317,26 @@ function CompetitionPortalPage ()  {
                     {/** This section will display the stats for the user's team otherwise shows default message telling them to find a team */}
                     
                     <section id = "portalStatsContent">
-                        {compUser.competitionTeam == null ? (
-                            <p id = "noTeamMessage">
-                                Uh oh! You’re not in a team yet. Either make your own team or ask your friends to share their invite code, 
-                                then navigate to Find Teams below to join their group!
-                           </p>
-                        )
-                        :
-                        <>
+
                          {isLoadingTeamInfo ? (
                             <Skeleton active></Skeleton>
                          ):
-                         <div>
-                         <p>Team Name: {teamInfo.teamName}</p>
-                       </div>
-                         }
-                        </>
-                            
+                          (  <>
+                                {compUser.competitionTeam == null ? (
+                                    <p id = "noTeamMessage">
+                                        Uh oh! You’re not in a team yet. Either make your own team or ask your friends to share their invite code, 
+                                        then navigate to Find Teams below to join their group!
+                                    </p>
+                                )
+                                : 
+                                    <div>
+                                        <p>Team Name: {teamInfo.teamName}</p>
+                                    </div>
+                                }
+                            </>
+                         )}
                         
-                        }
-                        
+
                     </section>
                 </Content>
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -91,6 +91,9 @@ const FindTeamsTab = (
     );
 };
 
+
+
+
   
 const LeaderBoardTab = ( ) => {
     return (
@@ -99,6 +102,10 @@ const LeaderBoardTab = ( ) => {
       </Content>
     );
 };
+
+
+
+
 
 
   const MyTeamTab = ( { compUser, fetchTeamsCallback}: {compUser: any, fetchTeamsCallback: () => void}) => {
@@ -120,12 +127,12 @@ const LeaderBoardTab = ( ) => {
         createTeam(compUser.competitionName, compUser.username, newTeamName).then((res) => {
             message.success('Successfully made a new team!');
             fetchTeamsCallback();
+            console.log(compUser)
         
         })
         .catch((error) => {
             message.error(error.message);
         });
-        setIsLoading(false);
 
     }
 
@@ -173,6 +180,8 @@ function CompetitionPortalPage ()  {
     const [activeTab, setActiveTab] = useState('1'); // Set the default active tab key
     const [isRegistered, setIsRegistered] = useState<any>(false);
 
+    const [isLoadingTeamInfo, setIsLoadingTeamInfo] = useState(false);
+    const [teamInfo, setTeamInfo] = useState<any>({});
     const competitionName  = "TestCompetition2";
 
 
@@ -225,13 +234,29 @@ function CompetitionPortalPage ()  {
 
         else {
             fetchTeams();
-        
         }
         
-      }, [user]);
+    }, [user]);
+
+    // only grab team info when user is in a team
+    useEffect(() => {
+        if(Object.keys(compUser).length !== 0){
+
+            if(compUser.competitionTeam != null){ 
+                console.log(compUser)
+                setIsLoadingTeamInfo(true);
+                getTeamInfo(competitionName, compUser.competitionTeam.teamName).then((res) => {
+                    setTeamInfo(res.data);
+                    setIsLoadingTeamInfo(false);
+
+                })  
+            }
+        }
+       
+    }, [compUser])
 
     
-      const onSubmit = () => {
+    const onSubmit = () => {
         registerCompetitionUser(competitionName, user.username).then((res) =>  {
             if (res.data.msg == "Success") {
                 window.location.reload();
@@ -284,11 +309,28 @@ function CompetitionPortalPage ()  {
                     </section>
 
                     {/** This section will display the stats for the user's team otherwise shows default message telling them to find a team */}
+                    
                     <section id = "portalStatsContent">
-                        <p id = "noTeamMessage">
-                            Uh oh! You’re not in a team yet. Either make your own team or ask your friends to share their invite code, 
-                            then navigate to Find Teams below to join their group!
-                        </p>
+                        {compUser.competitionTeam == null ? (
+                            <p id = "noTeamMessage">
+                                Uh oh! You’re not in a team yet. Either make your own team or ask your friends to share their invite code, 
+                                then navigate to Find Teams below to join their group!
+                           </p>
+                        )
+                        :
+                        <>
+                         {isLoadingTeamInfo ? (
+                            <Skeleton active></Skeleton>
+                         ):
+                         <div>
+                         <p>Team Name: {teamInfo.teamName}</p>
+                       </div>
+                         }
+                        </>
+                            
+                        
+                        }
+                        
                     </section>
                 </Content>
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
-import { Affix, AutoComplete, Avatar, Col, Drawer, List, Row, Skeleton, Tabs, Tooltip, message } from "antd";
+import { Affix, AutoComplete, Statistic, Drawer, List, Skeleton, Tabs, Tooltip, message } from "antd";
+import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
 import { Layout, Button, Input, Modal } from 'antd';
 import UserContext, { User } from "../../../UserContext";
 import { useHistory } from 'react-router-dom';
@@ -320,6 +321,7 @@ function CompetitionPortalPage ()  {
 
 
     const [barHeights, setBarHeights] = useState<number[]>([]);
+    const [scoreHistoryPercentage, setScoreHistoryPercentage] = useState<number>(0);
     const [scale, setScale] = useState<number>(1);
 
     // meta data for current competition
@@ -506,6 +508,12 @@ function CompetitionPortalPage ()  {
     
                 // Find the maximum score
                 const maxScore = Math.max(...scores);
+
+                // Find relative growth of scores
+                let lastTwo = scores.slice(-2);
+                const diff = lastTwo[1] - lastTwo[0];
+                const percent = diff / lastTwo[0];
+                setScoreHistoryPercentage(percent);
     
                  // Set your desired maximum height for the bars
                 const maxBarHeight = 92;
@@ -573,7 +581,10 @@ function CompetitionPortalPage ()  {
                     <section>
                         <span>
                             <h1 className="title2">Hello, {user.username}</h1>
-                            <Button icon = {<IoHelp size = {20}/>}></Button>
+                            <Tooltip title="Help">
+                                <Button icon = {<IoHelp size = {20}/>}></Button>
+
+                            </Tooltip>
 
                         </span>
                         <div id = "portalBanner">
@@ -627,7 +638,16 @@ function CompetitionPortalPage ()  {
                                         </div>
 
                                         <div className = "portalStatsBox">
-                                            <p>Score History</p>
+                                            <span>
+                                                <p>Score History</p>
+                                                <Statistic
+                                                    value={Math.abs(scoreHistoryPercentage)}
+                                                    precision={2}
+                                                    valueStyle={{ color: scoreHistoryPercentage < 0 ? '#cf1322' : '#3f8600', fontSize: "1.2rem", display:"inline" }}
+                                                    prefix={ scoreHistoryPercentage < 0 ?  <ArrowDownOutlined /> : <ArrowUpOutlined /> }
+                                                    suffix="%"
+                                                />
+                                            </span>
                                             <div id = "scoreHistoryChart">
                                                 {barHeights.map((height:number, index:any) => (
                                                     <Tooltip title={height}>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -20,7 +20,7 @@ import DefaultLayout from "../../../components/layouts/default";
 import { PaginationPosition, PaginationAlign } from "antd/es/pagination/Pagination";
 import { CompetitionData, getLeaderboard, getMetaData, getRanks, registerCompetitionUser, uploadSubmission } from "../../../actions/competition";
 import { genColor } from "../../../utils/colors";
-import { IoHelp } from "react-icons/io5";
+import { IoHelp, IoSearch } from "react-icons/io5";
 import { IoEllipsisVertical , IoPersonAdd} from "react-icons/io5";
 import { FaCheck, FaStar } from "react-icons/fa";
 import Table, { ColumnsType } from "antd/es/table";
@@ -87,7 +87,7 @@ const FindTeamsTab = (
                 size="large"
                 style={{ width: "100%" }}
             >
-                <Input size="large" placeholder="Look up a team name" />
+                <Input prefix={<IoSearch size = {20} style = {{marginRight: "0.5rem", color: "lightgrey"}} />}  size="large" placeholder="Look up a team name"  />
             </AutoComplete>
 
             {/** List to preview all the teams based on the user's query */}
@@ -403,7 +403,7 @@ const MyTeamTab = ({ isLoadingTeamInfo, compUser, rankData, metaData , fetchTeam
                             <div id="teamNameWrapper">
                                 <article>
                                     <h3>{compUser.competitionTeam.teamName}</h3>
-                                    <div id = "rankingTag">{getOrdinal(rankData.rank)} place</div>
+                                    <p id = "rankingTag">{getOrdinal(rankData.rank)} place</p>
                                 </article>
                             
                                 <Button size="large" id = "leaveTeamButton" onClick={showLeaveModal} icon = {<IoEllipsisVertical size = {28}/>}></Button>
@@ -423,7 +423,7 @@ const MyTeamTab = ({ isLoadingTeamInfo, compUser, rankData, metaData , fetchTeam
                         {/** TODO: Lowkey don't know what stats would work best here as everything besides the score is not finalized */}
                         <div id="teamScoreOverview">
                             <p className="statHeader">score</p>
-                            <p className="score">0</p>
+                            <p className="score">{rankData.score}</p>
                             <div id="teamScoreSpecifics">
                                 <div>
                                     <p className="statHeader">Sigma</p>
@@ -824,11 +824,7 @@ function CompetitionPortalPage() {
                     <section>
                         <span>
                             <h1 className="title2">Hello, {user.username}</h1>
-                            <Tooltip title="Help">
-                                <Button icon={<IoHelp size={20} />}></Button>
-
-                            </Tooltip>
-
+                            <Button size = "large"><p>Help</p></Button>
                         </span>
                         <div id="portalBanner">
                             <p>Welcome the the AI Portal for {competitionName}</p>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -345,9 +345,9 @@ const MyTeamTab = ({ isLoadingTeamInfo, compUser, rankData, teamInfo, metaData ,
             handleLeaveModalClose();
             fetchTeamsCallback();
         })
-            .catch((error) => (
-                message.error(error)
-            ));
+        .catch((error) => (
+            message.error(error)
+        ));
     }
 
     const handleClick = () => {
@@ -430,7 +430,7 @@ const MyTeamTab = ({ isLoadingTeamInfo, compUser, rankData, teamInfo, metaData ,
 
                         <div id="teamScoreHistorySection">
                             <h3>Score History</h3>
-                            <LineChart scoreHistory={teamInfo.scoreHistory.map(Number)}/>
+                            <LineChart scoreHistory={(teamInfo != null) ? teamInfo.scoreHistory.map(Number) : []}/>
                         </div>
 
                         <form id = "uploadFileSection">

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -28,6 +28,9 @@ import MainFooter from "../../../components/MainFooter";
 import { AxiosResponse } from "axios";
 import { BiStats } from "react-icons/bi";
 
+import { createAvatar } from '@dicebear/core';
+import { botttsNeutral } from '@dicebear/collection';
+
 const { Content } = Layout;
 
 
@@ -198,20 +201,51 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
         // TODO: replace placeholder link with actual file uploading logic
         action: 'https://run.mocky.io/v3/435e224c-44fb-4773-9faf-380c5e6a2188',
         onChange(info) {
-          const { status } = info.file;
-          if (status !== 'uploading') {
-            console.log(info.file, info.fileList);
-          }
-          if (status === 'done') {
-            message.success(`${info.file.name} file uploaded successfully.`);
-          } else if (status === 'error') {
-            message.error(`${info.file.name} file upload failed.`);
-          }
+            const { status } = info.file;
+            if (status !== 'uploading') {
+                console.log(info.file, info.fileList);
+            }
+            if (status === 'done') {
+                message.success(`${info.file.name} file uploaded successfully.`);
+            } else if (status === 'error') {
+                message.error(`${info.file.name} file upload failed.`);
+            }
         },
         onDrop(e) {
           console.log('Dropped files', e.dataTransfer.files);
         },
-      };
+    };
+
+    const TeamMemberAvatar: React.FC<{ username: string }> = ({ username }) => {
+        const [avatarUrl, setAvatarUrl] = useState('');
+        useEffect(() => {
+            // Generate avatar based on username using DiceBear
+            const svg = createAvatar(botttsNeutral, {
+              seed: username,
+              radius: 50,
+              backgroundType: ["gradientLinear"]
+            });
+        
+            // Convert the SVG string to a data URL
+            const dataUrl = `data:image/svg+xml;base64,${btoa(svg.toString())}`;
+        
+            // Set the avatar URL
+            setAvatarUrl(dataUrl);
+        }, [username]);
+        return (
+            <img
+                src={avatarUrl} 
+                style={
+                    {
+                        width: '4rem',
+                        height: '4rem',
+                        marginRight: '0.75rem'
+                    }
+                }
+                alt={`Avatar for ${username}`} 
+            />
+        );
+    }
 
     const generateTeamPicture = () => {
 
@@ -321,7 +355,6 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
                         </form>
                         
                         <h3 className="mainHeader">Submission Log</h3>
-
                     </div>
 
                     {/* <Affix style={{ position: 'absolute', right: 0, top: 10,}} offsetTop={20}> */}
@@ -332,8 +365,8 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
                         </div>
                         {compUser.competitionTeam.teamMembers.map((member: string, index: number) => (
                             <div id="teamMember" key={index}>
-                                {generateTeamPicture()}
-                                <div>
+                                <TeamMemberAvatar username={member}></TeamMemberAvatar>
+                                <div className="teamMemberTextWrapper">
                                     <p className="teamMemberName">{member}</p>
                                     <p>0 submissions</p>
                                 </div>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -188,17 +188,18 @@ const LeaderBoardTab = ( ) => {
 
         {compUser.competitionTeam !== null && (
             <section>
-                <span>
+                <span id = "team">
                     {generateTeamPicture()}
+                    <div>
                         <h3>{compUser.competitionTeam.teamName}</h3>
+                    </div>
 
                 </span>
                 
                 <Affix style={{ position: 'absolute', top: 10, right: 0 }} offsetTop={100}>
                     <div id = "teamAffix">
 
-                    <h3>Members</h3>
-                    <p>Description</p>
+                    <h3>Team Members</h3>
                     </div>
                 </Affix>
             </section>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -199,7 +199,7 @@ const LeaderBoardTab = ( ) => {
                 <Affix style={{ position: 'absolute', top: 10, right: 0 }} offsetTop={100}>
                     <div id = "teamAffix">
 
-                    <h3>Team Members</h3>
+                    <h4>Team Members</h4>
                     </div>
                 </Affix>
             </section>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -371,7 +371,7 @@ const MyTeamTab = ({ compUser, fetchTeamsCallback }: { compUser: any, fetchTeams
                     <div id="teamAffix">
                         <div id="teamMembersHeader">
                             <h3 className="heading">Team Members</h3>
-                            <Button id="inviteButton" onClick={showInviteModal}>Invite</Button>
+                            <Button size = "large" id="inviteButton" onClick={showInviteModal}>Invite</Button>
                             <Modal cancelButtonProps={{ style: { display: 'none' } }} title="Invite friends to your team" open={isInviteModalVisible} onOk={handleInviteModalClose}>
                                 <p>Share your Invite Code to your friend. Make sure to tell them your team name as well!</p>
                                 {/* TODO: For some reason, I couldn't get the CSS to show up when I put it in the CSS file */}

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -262,20 +262,59 @@ const MyTeamTab = ( { compUser, fetchTeamsCallback}: {compUser: any, fetchTeamsC
 
         {compUser.competitionTeam !== null && (
             <section>
-                <span id = "team">
-                    {generateTeamPicture()}
-                    <div>
-                        <h3>{compUser.competitionTeam.teamName}</h3>
-                    </div>
-
-                </span>
+                <div id = "teamMainContent">
+                        <div id = "teamHeader">
+                            {generateTeamPicture()}
+                            <div>
+                                <h3>{compUser.competitionTeam.teamName}</h3>
+                                <p>nth place</p>
+                            </div>
+                        </div>
+                        
+                        <div id = "teamScoreOverview">
+                            <p className = "statHeader">score</p>
+                            <p className = "score">0</p>
+                            <div id = "teamScoreSpecifics">
+                                <div>
+                                    <p className = "statHeader">Sigma</p>
+                                    <p className = "stat">0.78</p>
+                                </div>
+                                <div>
+                                    <p className = "statHeader">Mu</p>
+                                    <p className = "stat">0.78</p>
+                                </div>
+                                <div>
+                                    <p className = "statHeader">MSE</p>
+                                    <p className = "stat">0.78</p>
+                                </div>
+                            </div>
+                        </div>
+                        <form>
+                            <h3 className="mainHeader">Upload File</h3>
+                            <input type="file" />
+                            <button type="submit">Upload</button>
+                        </form>
+                        <h3 className="mainHeader">Submission Log</h3>
+                        {/* <p id = "teamDescription">fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds jdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfdsjdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj fsdfdsfds dfsdf sfh jkkdjhk jdshfk kkjkj </p> */}
+                </div>
                 
-                <Affix style={{ position: 'absolute', right: 0, top: 10}} offsetTop={20}>
+                {/* <Affix style={{ position: 'absolute', right: 0, top: 10,}} offsetTop={20}> */}
                     <div id = "teamAffix">
-
-                    <h4>Team Members</h4>
+                        <div id = "teamMembersHeader">
+                            <h3 className= "heading">Team Members</h3>
+                            <Button id = "inviteButton">Invite</Button>
+                        </div>
+                        {compUser.competitionTeam.teamMembers.map((member: string, index: number) => (
+                            <div id = "teamMember" key={index}>
+                                {generateTeamPicture()}
+                                <div>
+                                    <p className="teamMemberName">{member}</p>
+                                    <p>0 submissions</p>
+                                </div>
+                            </div>
+                        ))}
                     </div>
-                </Affix>
+                {/* </Affix> */}
             </section>
         )}
         

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -601,7 +601,7 @@ function CompetitionPortalPage ()  {
                                     <section id = "portalStatsRow">
                                         <div className = "portalStatsBox">
                                             <span>
-                                                <FaCheck size = {20} style = {{padding: "6px", borderRadius: "8px", color: "blue", background: "lightblue", marginRight: "1rem"}}/>
+                                                <FaCheck size = {20} style = {{padding: "6px", borderRadius: "8px", color: "#ff6f6f", background: "pink", marginRight: "1rem"}}/>
                                                 <p>Your Submissions</p>
                                             </span>
 
@@ -611,7 +611,7 @@ function CompetitionPortalPage ()  {
 
                                         <div className = "portalStatsBox">
                                             <span>
-                                                <BiStats size = {24} style = {{padding: "4px", borderRadius: "8px", color: "green", background: "lightgreen", marginRight: "1rem"}}/>
+                                                <BiStats size = {24} style = {{padding: "4px", borderRadius: "8px", color: "#fe8019", background: "#FCC777", marginRight: "1rem"}}/>
                                                 <p>Best Score</p>
                                             </span>
                                             

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -147,9 +147,9 @@ const LeaderBoardTab = (
       <Content id="leaderBoardContainer">
             <section>
 
-                <p style={{ marginBottom: '12px', fontWeight: 600 }}>
-                    (Table last refreshed{': '}
-                    {lastRefresh ? lastRefresh.toLocaleString() : ''})
+                <p style={{ marginRight: '24px'}}>
+                    Last refreshed{': '}
+                    {lastRefresh ? lastRefresh.toLocaleString() : ''}
                 </p>
                 <Button
                     size="large"
@@ -260,7 +260,7 @@ const MyTeamTab = ( { compUser, fetchTeamsCallback}: {compUser: any, fetchTeamsC
 
                 </span>
                 
-                <Affix style={{ position: 'absolute', top: 10, right: 0 }} offsetTop={100}>
+                <Affix style={{ position: 'absolute', right: 0, top: 10}} offsetTop={20}>
                     <div id = "teamAffix">
 
                     <h4>Team Members</h4>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -70,8 +70,8 @@ const FindTeamsTab = (
             filterOption = {(inputValue, option) => 
                 option!.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
             }
-            size = "large"
-            style = {{width: "100%", fontSize: 1.4}}
+            size="large"
+            style = {{width: "100%"}}
         >
             <Input.Search size="large" placeholder="Look up a team name" enterButton />
         </AutoComplete>
@@ -79,7 +79,7 @@ const FindTeamsTab = (
         {/** List to preview all the teams based on the user's query */}
         <List
             split = {false}
-            pagination={{ position, align}}
+            pagination={{ position, align, pageSize: 6}}
             dataSource={options}
             renderItem={(team: any) => (
             <List.Item key = {team.competitionName}>


### PR DESCRIPTION
This branch includes all previous changes made to the header, find teams tab, and stats UI changes for the my team tab

## For the header: 
I added another card to display the total matches played for the current team
![image](https://github.com/acmucsd/acm-ai-site/assets/91165559/69e6c2ee-b4d5-4153-a469-61e2b60a255f)

## For the find teams tab:
I simplified the team cards by removing icons and displaying the bare essential information
![image](https://github.com/acmucsd/acm-ai-site/assets/91165559/4113d782-8bf4-424f-8c35-889c9fb83c08)


 ## For the my teams tab: 
I added a chartjs graph for the score history, touched up some UI styling with Jenny, and added a box to later display a list of all matches for the team
![image](https://github.com/acmucsd/acm-ai-site/assets/91165559/c13261f9-1dd0-42f3-9ab6-bc2c2d2adc02)
