### PR TITLE
Admin registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6441,9 +6441,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001519",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
+      "version": "1.0.30001651",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
+      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6457,7 +6457,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-router-dom';
 import { UserProvider } from './UserContext';
 import { TournamentProvider } from './contexts/tournament';
+import {AdminBooleanProvider} from './contexts/admin';
 import { Spin } from 'antd';
 import { LoadingOutlined } from '@ant-design/icons';
 
@@ -116,7 +117,19 @@ function App() {
                 component={HideAndSeek2020Page}
               />
               <Route path="/events" exact component={EventsPage} />
-              <Route path="/register" exact component={RegisterPage} />
+
+              <Router>
+                <AdminBooleanProvider currAdminStatus={false}> 
+                  <Route path="/register" exact component={RegisterPage} />
+                </AdminBooleanProvider>
+              </Router>
+
+              <Router>
+                <AdminBooleanProvider currAdminStatus={true}> 
+                  <Route path="/admin/register" exact component={RegisterPage} />
+                </AdminBooleanProvider>
+              </Router>
+
               <Route
                 path="/eventhasnotstarted"
                 exact

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,17 +118,13 @@ function App() {
               />
               <Route path="/events" exact component={EventsPage} />
 
-              <Router>
-                <AdminBooleanProvider currAdminStatus={false}> 
-                  <Route path="/register" exact component={RegisterPage} />
-                </AdminBooleanProvider>
-              </Router>
+              <AdminBooleanProvider currAdminStatus={false}> 
+                <Route path="/register" exact component={RegisterPage} />
+              </AdminBooleanProvider>
 
-              <Router>
-                <AdminBooleanProvider currAdminStatus={true}> 
-                  <Route path="/admin/register" exact component={RegisterPage} />
-                </AdminBooleanProvider>
-              </Router>
+              <AdminBooleanProvider currAdminStatus={true}> 
+                <Route path="/admin/register" exact component={RegisterPage} />
+              </AdminBooleanProvider>
 
               <Route
                 path="/eventhasnotstarted"

--- a/src/contexts/admin.tsx
+++ b/src/contexts/admin.tsx
@@ -20,6 +20,4 @@ export const AdminBooleanProvider: React.FC<{ children: ReactNode; currAdminStat
   );
 };
 
-// Optionally define a Consumer if needed
-// export const AdminBooleanConsumer = AdminBooleanContext.Consumer;
 export default AdminBooleanContext;

--- a/src/contexts/admin.tsx
+++ b/src/contexts/admin.tsx
@@ -1,0 +1,25 @@
+import React, { useState,createContext, ReactNode } from 'react';
+
+// Define the type for the context value
+interface AdminBooleanContextType {
+  isAdmin: boolean;
+  setIsAdmin: (isAdmin: boolean) => void;
+}
+
+// Create the context with a default value
+const AdminBooleanContext = createContext<AdminBooleanContextType | undefined>(undefined);
+
+// Define the provider component
+export const AdminBooleanProvider: React.FC<{ children: ReactNode; currAdminStatus: boolean }> = ({ children, currAdminStatus }) => {
+  const [isAdmin, setIsAdmin] = useState<boolean>(currAdminStatus);
+
+  return (
+    <AdminBooleanContext.Provider value={{ isAdmin, setIsAdmin }}>
+      {children}
+    </AdminBooleanContext.Provider>
+  );
+};
+
+// Optionally define a Consumer if needed
+// export const AdminBooleanConsumer = AdminBooleanContext.Consumer;
+export default AdminBooleanContext;

--- a/src/pages/Auth/RegisterPage/index.tsx
+++ b/src/pages/Auth/RegisterPage/index.tsx
@@ -1,13 +1,27 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import './index.less';
 import DefaultLayout from '../../../components/layouts/default';
 import { Form, Input, message, Button, Checkbox, Layout } from 'antd';
 import { useForm, Controller } from 'react-hook-form';
 import { registerUser } from '../../../actions/auth';
 import { useHistory, Link } from 'react-router-dom';
+import AdminBooleanContext from '../../../contexts/admin';
+
 const { Content } = Layout;
 
 function RegisterPage() {
+
+  const context = useContext(AdminBooleanContext);
+
+  if (context === undefined) {
+    throw new Error('RegisterPage must be used within an AdminBooleanProvider');
+  }
+
+  const {isAdmin}  = context;
+
+  console.log("isAdmin: ", isAdmin)
+  // const isAdmin = true
+
   const history = useHistory();
   const { handleSubmit, watch, errors, control } = useForm();
   const [checked, setChecked] = useState(true);
@@ -15,25 +29,46 @@ function RegisterPage() {
     if (errors.confirmPassword) {
       handlePasswordErrors(errors);
     }
-    registerUser({ ...values, isUCSD: checked }).then((res) => {
-      message.success('Registered! Redirecting to login page');
-      history.push('/login');
-    });
+
+    if( isAdmin ){
+      registerUser({ ...values, isUCSD: checked, admin: true }).then((res) => {
+        message.success('Admin registered! Redirecting to login page');
+        history.push('/login');
+      });
+
+    }else{
+      registerUser({ ...values, isUCSD: checked, admin: false }).then((res) => {
+        message.success('Registered! Redirecting to login page');
+        history.push('/login');
+      });
+    }
   };
   const onCheckChange = (e: any) => {
     setChecked(e.target.checked);
   };
+
+  const handleChangeAdmin = () => {
+    const {setIsAdmin} = context
+    setIsAdmin(!isAdmin)
+  }
+
   return (
     <DefaultLayout>
       <div className="RegisterPage">
         <Content className="registerDetails">
           <div className="registerHeader">
-            <h2>Register</h2>
-            <p>
-              An ACM AI account will help you get the most out of our events and
-              opportunities whether it be for awesome competitions or cool
-              networking events!
-            </p>
+            {
+              isAdmin ? <h2>Admin Register</h2> : 
+              (<>
+                <h2>Register</h2>
+                <p>
+                An ACM AI account will help you get the most out of our events and
+                opportunities whether it be for awesome competitions or cool
+                networking events!
+                </p>
+              </>
+              )
+            }
           </div>
 
           <Form onSubmitCapture={handleSubmit(onSubmit)}>
@@ -108,7 +143,7 @@ function RegisterPage() {
                 validate: (value) => watch('password') === value,
               }}
             />
-            <Controller
+            { isAdmin ? <></>: <Controller
               as={
                 <Form.Item>
                   <Checkbox value={checked} onChange={onCheckChange}>
@@ -118,7 +153,7 @@ function RegisterPage() {
               }
               name="isUCSD"
               control={control}
-            />
+            />}
 
             <div className="errorBox">
               {errors.username && <p className="danger">Missing username</p>}
@@ -150,10 +185,18 @@ function RegisterPage() {
           </Form>
 
           <div className="loginLink">
-            <Link to="./login">
-              <p>Already have an account? Log in</p>
+            <Link to='./login'>
+            <p>Already have an account? Log in</p>
             </Link>
+            {/* {
+              isAdmin ? 
+              <p onClick={handleChangeAdmin}>Register for general member account</p>
+               :
+              <p onClick={handleChangeAdmin}>Register for admin account</p>
+            } */}
+            
           </div>
+
         </Content>
       </div>
     </DefaultLayout>

--- a/src/pages/Auth/RegisterPage/index.tsx
+++ b/src/pages/Auth/RegisterPage/index.tsx
@@ -19,9 +19,6 @@ function RegisterPage() {
 
   const {isAdmin}  = context;
 
-  console.log("isAdmin: ", isAdmin)
-  // const isAdmin = true
-
   const history = useHistory();
   const { handleSubmit, watch, errors, control } = useForm();
   const [checked, setChecked] = useState(true);
@@ -47,10 +44,10 @@ function RegisterPage() {
     setChecked(e.target.checked);
   };
 
-  const handleChangeAdmin = () => {
-    const {setIsAdmin} = context
-    setIsAdmin(!isAdmin)
-  }
+  // const handleChangeAdmin = () => {
+  //   const {setIsAdmin} = context
+  //   setIsAdmin(!isAdmin)
+  // }
 
   return (
     <DefaultLayout>

--- a/src/pages/Auth/RegisterPage/index.tsx
+++ b/src/pages/Auth/RegisterPage/index.tsx
@@ -44,18 +44,13 @@ function RegisterPage() {
     setChecked(e.target.checked);
   };
 
-  // const handleChangeAdmin = () => {
-  //   const {setIsAdmin} = context
-  //   setIsAdmin(!isAdmin)
-  // }
-
   return (
     <DefaultLayout>
       <div className="RegisterPage">
         <Content className="registerDetails">
           <div className="registerHeader">
             {
-              isAdmin ? <h2>Admin Register</h2> : 
+              isAdmin ? <h2>Register as Admin</h2> : 
               (<>
                 <h2>Register</h2>
                 <p>
@@ -185,13 +180,6 @@ function RegisterPage() {
             <Link to='./login'>
             <p>Already have an account? Log in</p>
             </Link>
-            {/* {
-              isAdmin ? 
-              <p onClick={handleChangeAdmin}>Register for general member account</p>
-               :
-              <p onClick={handleChangeAdmin}>Register for admin account</p>
-            } */}
-            
           </div>
 
         </Content>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": [
     "src"


### PR DESCRIPTION
Addresses issue Add admin registration page #133 


Reused the existing registration page and display admin registration according to the if boolean context variable passed in from AdminBooleanContextProvider is true. Created new context file `admin.tsx`.

Note that admin page doesn't display From UCSD checkbox and that admin's isUCSD field is automatically set to true.

Admin registration is under the URL `http://localhost:3000/admin/register` and is not currently linked from anywhere (need to manually input the URL to access the page) 


<img width="1280" alt="image" src="https://github.com/user-attachments/assets/0433bc48-5971-4730-a3c0-26ab4d797443">
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/2b8f99de-58ac-4152-88f6-ca2024295585">


