### PR TITLE
changed reset password page styling

### DIFF
--- a/src/pages/Auth/ForgotPassword/index.less
+++ b/src/pages/Auth/ForgotPassword/index.less
@@ -1,19 +1,48 @@
 @import '../../../styles/base.less';
-.LoginPage {
+@import '../../../newStyles/text.less';
+@import '../../../newStyles/components.less';
+@import '../../../newStyles/variables.less';
 
-  .danger {
-    color: @danger;
+.RegisterPage {
+  .noContainer();
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .registerContent {
+    .generic-centered-section();
+    .constrained-bounds();
+    
+    .registerHeader {
+      margin-top: 4rem;
+    }
+
+    p {
+      margin-top: 1rem;
+      text-align: center;
+    }
+
+    form {
+      Input {
+        line-height: 2.5rem ;
+        font-size: @font3;
+      }
+
+      .danger {
+        color: @danger;
+        text-align: left;
+        margin-top: -12px;
+        margin-bottom: 24px;
+      }
+    }
+
+    .registerButton {
+      width: 100%;
+      height:45px;
+      .button-black-square();
+      margin: auto;
+      font-size: 18px;
+    }
   }
-  .loginButton {
-    margin-top: @margin-base;
-    width: 100%;
-  }
-  .loginCard {
-    margin: auto;
-    .smack-center();
-    max-width: 90%;
-  }
-  .register-info {
-    margin-top: 12px;
-  }
+ 
 }

--- a/src/pages/Auth/ForgotPassword/index.tsx
+++ b/src/pages/Auth/ForgotPassword/index.tsx
@@ -86,7 +86,7 @@ function ForgotPasswordPage({ location }: RouteComponentProps) {
                 <p className="danger">Passwords need to match</p>
               )}
               <Button htmlType="submit" className="registerButton">
-                Send Reset Link
+                Reset
               </Button>
               <div className="authOptionsBox">
                 <Link to="./login">

--- a/src/pages/Auth/ForgotPassword/index.tsx
+++ b/src/pages/Auth/ForgotPassword/index.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
 import './index.less';
 import DefaultLayout from '../../../components/layouts/default';
-import Card from '../../../components/Card';
 import { Form, Input, message, Button } from 'antd';
 import { useForm, Controller } from 'react-hook-form';
 import { resetPassword } from '../../../actions/auth';
-import { useHistory, RouteComponentProps } from 'react-router-dom';
+import { useHistory, RouteComponentProps, Link } from 'react-router-dom';
 import query from 'querystring';
+import { Layout } from 'antd';
+const { Content } = Layout;
 
 function ForgotPasswordPage({ location }: RouteComponentProps) {
   const history = useHistory();
@@ -31,10 +31,13 @@ function ForgotPasswordPage({ location }: RouteComponentProps) {
   return (
     <DefaultLayout>
       <div className="RegisterPage">
-        <Card className="registerCard">
+        <Content className="registerContent">
           <div className="cardContent">
-            <h2 style={{ margin: 0 }}>Forgot Password?</h2>
-            <p>Enter your new password</p>
+            <div className='registerHeader'>
+              <h2 style={{ margin: 0 }}>Forgot Password?</h2>
+              <p>Enter your new password</p>
+            </div>
+            
             <br />
             <form onSubmit={handleSubmit(onSubmit)}>
               <Controller
@@ -83,11 +86,16 @@ function ForgotPasswordPage({ location }: RouteComponentProps) {
                 <p className="danger">Passwords need to match</p>
               )}
               <Button htmlType="submit" className="registerButton">
-                Reset
+                Send Reset Link
               </Button>
+              <div className="authOptionsBox">
+                <Link to="./login">
+                  <p className="option">Back to Login</p>
+                </Link>
+              </div>
             </form>
           </div>
-        </Card>
+        </Content>
       </div>
     </DefaultLayout>
   );


### PR DESCRIPTION
This PR is for issue #148 

- updated the styling to fit more of what we see for the Login page
- removed CSS code that didn't match the classes on the index.tsx file for the ForgotPassword page in the Auth folder
- removed the need for a Card component for page layout

![image](https://github.com/user-attachments/assets/2fa5d21f-82f6-48ee-917d-9d8a0e50ce25)

![image](https://github.com/user-attachments/assets/b9c499ed-b1da-41da-89d3-9482c130d5e5)

