### PR TITLE
StarChess admin portal page and WLD features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ import JoinTeamsPage from './pages/Competitions/CompetitionTeamPages/JoinTeamsPa
 import SubmissionLogPage from './pages/Competitions/CompetitionPortalPage/SubmissionLogPage';
 import MatchesPage from './pages/Competitions/CompetitionPortalPage/MatchesPage';
 import ProfilePage from './pages/ProfilePage';
+import AdminPortalPage from './pages/AdminPortalPage';
 
 let cookie = getCookie(COOKIE_NAME);
 
@@ -187,6 +188,7 @@ function App() {
               <Route path="/requestreset" component={requestreset} /> 
               <Route path="/resetpassword" component={ForgotPasswordPage} />
               <Route path="/admin/register" exact component={RegisterPage} />
+              <Route path="/admin/portal" exact component={AdminPortalPage} />
 
               {/* old competitions */}
               <Route  path="/old-competitions/hideandseek" exact component={HideAndSeek2020Page} />

--- a/src/actions/competition.ts
+++ b/src/actions/competition.ts
@@ -15,10 +15,10 @@ export interface CompetitionData {
     team: string;
     score: number;
     submitHistory: Array<string>;
-    scoreHistory?: Array<number>;
-    winHistory?: Array<number>;
-    drawHistory?: Array<number>;
-    lossHistory?: Array<number>;
+    scoreHistory: Array<number>;
+    winHistory: Array<number>;
+    drawHistory: Array<number>;
+    lossHistory: Array<number>;
 }
 
 export const uploadSubmission = async (
@@ -65,6 +65,7 @@ export const uploadCompetitionResults = async (
   file: File | undefined,
   competitionid: string,
 ): Promise<AxiosResponse> => {
+  
   if (!file) {
     throw new Error('no file!');
   }
@@ -75,7 +76,8 @@ export const uploadCompetitionResults = async (
   const token = getToken(COOKIE_NAME);
   return new Promise((resolve, reject) => {
     const bodyFormData = new FormData();
-    bodyFormData.set('results', file);
+    const csvFile = new File([file], file.name, {type: 'text/csv'});
+    bodyFormData.append('results', csvFile);
 
     axios
       .post(

--- a/src/actions/competition.ts
+++ b/src/actions/competition.ts
@@ -57,6 +57,60 @@ export const uploadSubmission = async (
   });
 };
 
+export const uploadCompetitionResults = async (
+  file: File | undefined,
+  competitionid: string,
+  uploadedBy: string
+): Promise<AxiosResponse> => {
+  if (!file) {
+    throw new Error('no file!');
+  }
+  if (!competitionid) {
+    throw new Error('competition ID not specified!');
+  }
+  if (!uploadedBy) {
+    throw new Error('Admin user not identified for upload!');
+  }
+
+  const token = getToken(COOKIE_NAME);
+  return new Promise((resolve, reject) => {
+    const bodyFormData = new FormData();
+    bodyFormData.set('results', file);
+    bodyFormData.set('uploadedBy', uploadedBy);
+
+    axios
+      .post(
+        process.env.REACT_APP_API + 
+          `/v1/competitions/${competitionid}/uploadResults`,
+        bodyFormData,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'multipart/form-data',
+          },
+        }
+
+      )
+      .then((res: AxiosResponse) => {
+        resolve(res);
+      })
+      .catch((error) => {
+        message.error(error);
+        reject(error);
+      });
+  });
+}
+
+export const getCompetitions = async () => {
+  try {
+    const response = await axios.get(process.env.REACT_APP_API + `/v1/competitions`);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching competitions:', error);
+    throw error;
+  }
+}
+
 export const getMetaData = async (
   competitionid: string
 ): Promise<AxiosResponse> => {

--- a/src/actions/competition.ts
+++ b/src/actions/competition.ts
@@ -60,7 +60,6 @@ export const uploadSubmission = async (
 export const uploadCompetitionResults = async (
   file: File | undefined,
   competitionid: string,
-  uploadedBy: string
 ): Promise<AxiosResponse> => {
   if (!file) {
     throw new Error('no file!');
@@ -68,15 +67,11 @@ export const uploadCompetitionResults = async (
   if (!competitionid) {
     throw new Error('competition ID not specified!');
   }
-  if (!uploadedBy) {
-    throw new Error('Admin user not identified for upload!');
-  }
 
   const token = getToken(COOKIE_NAME);
   return new Promise((resolve, reject) => {
     const bodyFormData = new FormData();
     bodyFormData.set('results', file);
-    bodyFormData.set('uploadedBy', uploadedBy);
 
     axios
       .post(

--- a/src/actions/competition.ts
+++ b/src/actions/competition.ts
@@ -15,6 +15,10 @@ export interface CompetitionData {
     team: string;
     score: number;
     submitHistory: Array<string>;
+    scoreHistory?: Array<number>;
+    winHistory?: Array<number>;
+    drawHistory?: Array<number>;
+    lossHistory?: Array<number>;
 }
 
 export const uploadSubmission = async (

--- a/src/actions/teams/utils.ts
+++ b/src/actions/teams/utils.ts
@@ -56,13 +56,13 @@ export const getTeamInfo = async (
   teamName: string
 ): Promise<AxiosResponse> => {
   let token = getToken(COOKIE_NAME);
+  const encodedTeamName = encodeURIComponent(teamName);
+  console.log("encode", encodedTeamName);
   return new Promise((resolve, reject) => {
     axios
       .get(
-        // TODO: remove hardcoded thing
-        // `http://localhost:9000/v1/competitions/teams/${competitionName}/${teamName}`,
         process.env.REACT_APP_API +
-          `/v1/competitions/teams/${competitionName}/${teamName}`,
+          `/v1/competitions/teams/${competitionName}/${encodedTeamName}`,
         {
           headers: {
             Authorization: `Bearer ${token}`,

--- a/src/pages/AdminPortalPage/index.less
+++ b/src/pages/AdminPortalPage/index.less
@@ -24,4 +24,11 @@
       margin-bottom: 0;
     }
   }
+
+  .compResults {
+    .generic-section();
+    h2 {
+      font-size: @font5;
+    }
+  }
 }

--- a/src/pages/AdminPortalPage/index.less
+++ b/src/pages/AdminPortalPage/index.less
@@ -1,0 +1,27 @@
+@import '../../newStyles/text.less';
+@import '../../newStyles/components.less';
+@import '../../newStyles/index.less';
+
+.AdminPortalPage {
+  // removes any default white space margins
+  .noContainer();
+
+  // prevents layout shifts caused by scrollbar
+  overflow-y: hidden;
+  background: @white;
+
+
+  .profileHeader {
+    padding: 2rem;
+
+    display: flex;
+
+    h1 .profileName {
+      color: @orange;
+    }
+
+    h1 {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/pages/AdminPortalPage/index.tsx
+++ b/src/pages/AdminPortalPage/index.tsx
@@ -1,13 +1,15 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import './index.less';
 import DefaultLayout from '../../components/layouts/default';
 import {
   profileData,
   UserProfile,
 } from '../../actions/users';
-import { Row, Col, Layout, Button, Modal, Flex, Select, message } from 'antd';
+import { Row, Col, Layout, Button, Flex, message, Upload, Space } from 'antd';
 import MainFooter from '../../components/MainFooter';
 import { useHistory } from 'react-router-dom';
+import { UploadOutlined } from '@ant-design/icons';
+// import { uploadCompetitionResults } from '../../actions/competition';
 const { Content } = Layout;
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -18,7 +20,8 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 export default function AdminPortalPage(props: any) {
   const [user, setUser] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
-
+  const [uploadingResults, setUploadingResults] = useState(false);
+  const [resultsFile, setResultsFile] = useState<File | null>(null);
   const history = useHistory();
 
   const checkAdminAccess = useCallback((profile: UserProfile | null) => {
@@ -46,6 +49,59 @@ export default function AdminPortalPage(props: any) {
     loadProfileData();
   }, [loadProfileData]);
 
+  const handleResultsFileChange = (info: any) => {
+    if (info.file.status === 'done') {
+      message.success(`${info.file.name} file selected successfully`);
+      setResultsFile(info.file.originFileObj as File);
+    } else if (info.file.status === 'removed') {
+      setResultsFile(null);
+    }
+  };
+
+  const beforeResultsUpload = (file: File) => {
+    const isCSV = file.type === 'text/csv' || file.name.endsWith('.csv');
+    if (!isCSV) {
+      message.error('You can only upload CSV files for results!');
+    }
+    return isCSV;
+  };
+
+  // Prevent the default upload behavior
+  const dummyRequest = ({ onSuccess }: any) => {
+    setTimeout(() => {
+      onSuccess('ok');
+    }, 0);
+  };
+
+  const handleUploadResults = () => {
+    if (!resultsFile) {
+      message.error('Please select a CSV file to upload for competition results.');
+      return;
+    }
+
+    setUploadingResults(true);
+
+    // uploadCompetitionResults(resultsFile)
+    //   .then(() => {
+    //     message.success('Competition results uploaded successfully!');
+    //     setResultsFile(null);
+    //   })
+    //   .catch((error) => {
+    //     message.error('Failed to upload competition results.');
+    //     console.error('Upload error:', error);
+    //   })
+    //   .finally(() => {
+    //     setUploadingResults(false);
+    //   });
+
+    // simulating
+    setTimeout(() => {
+      message.success('Simulated: Competition results uploaded successfully!');
+      setResultsFile(null);
+      setUploadingResults(false);
+    }, 1000);
+  };
+
   if (loading) {
     return <DefaultLayout>Loading...</DefaultLayout>;
   }
@@ -58,24 +114,48 @@ export default function AdminPortalPage(props: any) {
     <DefaultLayout>
       <Content className="AdminPortalPage">
         <Content>
-            <Flex
-                className="profileHeader"
-                justify="space-between"
-                align="center"
+          <Flex
+            className="profileHeader"
+            justify="space-between"
+            align="center"
+          >
+            <h1 className="title2">
+              {!loading && user ? (
+                <>
+                  Welcome admin,{' '}
+                  <span className="profileName">{user.username}.</span>
+                </>
+              ) : (
+                <></>
+              )}
+            </h1>
+          </Flex>
+
+          <div className="compResults">
+            <h2>Upload Competition Results</h2>
+            <p>Select a CSV file containing competition results.</p>
+
+            <Upload
+              beforeUpload={beforeResultsUpload}
+              onChange={handleResultsFileChange}
+              maxCount={1}
+              accept=".csv, text/csv"
+              onRemove={() => setResultsFile(null)}
+              customRequest={dummyRequest}
             >
-                <h1 className="title2">
-                {!loading && user ? (
-                    <>
-                    Welcome admin,{' '}
-                    <span className="profileName">{user.username}.</span>
-                    </>
-                ) : (
-                    <></>
-                )}
-                </h1>
-            </Flex>
+              <Button icon={<UploadOutlined />}>Select CSV File</Button>
+            </Upload>
 
-
+            <Button
+              type="primary"
+              onClick={handleUploadResults}
+              disabled={!resultsFile || uploadingResults}
+              loading={uploadingResults}
+              style={{ marginTop: '10px' }}
+            >
+              Upload Results
+            </Button>
+          </div>
         </Content>
         <MainFooter />
       </Content>

--- a/src/pages/AdminPortalPage/index.tsx
+++ b/src/pages/AdminPortalPage/index.tsx
@@ -105,14 +105,10 @@ export default function AdminPortalPage(props: any) {
       message.error('Please select a competition to upload results for.');
       return;
     }
-    if (!user?.username) {
-      message.error('Could not identify user');
-      return;
-    }
 
     setUploadingResults(true);
 
-    uploadCompetitionResults(resultsFile, selectedCompetition, user.username)
+    uploadCompetitionResults(resultsFile, selectedCompetition)
       .then(() => {
         message.success('Competition results uploaded successfully!');
         setResultsFile(null);

--- a/src/pages/AdminPortalPage/index.tsx
+++ b/src/pages/AdminPortalPage/index.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import './index.less';
+import DefaultLayout from '../../components/layouts/default';
+import {
+  profileData,
+  UserProfile,
+} from '../../actions/users';
+import { Row, Col, Layout, Button, Modal, Flex, Select, message } from 'antd';
+import MainFooter from '../../components/MainFooter';
+import { useHistory } from 'react-router-dom';
+const { Content } = Layout;
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  year: 'numeric',
+});
+
+export default function AdminPortalPage(props: any) {
+  const [user, setUser] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const history = useHistory();
+
+  const checkAdminAccess = useCallback((profile: UserProfile | null) => {
+    if (!profile?.admin) {
+      message.error('You do not have access to this page.');
+      history.push('/profile');
+      return false;
+    }
+    return true;
+  }, [history]);
+
+  const loadProfileData = useCallback(() => {
+    profileData()
+      .then((res) => {
+        setUser(res);
+        setLoading(false);
+        checkAdminAccess(res);
+      })
+      .catch(() => {
+        history.push('/login');
+      });
+  }, [history, checkAdminAccess]);
+
+  useEffect(() => {
+    loadProfileData();
+  }, [loadProfileData]);
+
+  if (loading) {
+    return <DefaultLayout>Loading...</DefaultLayout>;
+  }
+
+  if (!user?.admin) {
+    return null;
+  }
+
+  return (
+    <DefaultLayout>
+      <Content className="AdminPortalPage">
+        <Content>
+            <Flex
+                className="profileHeader"
+                justify="space-between"
+                align="center"
+            >
+                <h1 className="title2">
+                {!loading && user ? (
+                    <>
+                    Welcome admin,{' '}
+                    <span className="profileName">{user.username}.</span>
+                    </>
+                ) : (
+                    <></>
+                )}
+                </h1>
+            </Flex>
+
+
+        </Content>
+        <MainFooter />
+      </Content>
+    </DefaultLayout>
+  );
+}

--- a/src/pages/Competitions/CompetitionPortalPage/FindTeams.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/FindTeams.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from "react";
+import { Content } from 'antd/lib/layout/layout';
+import { AutoComplete, Input, List } from 'antd';
+import { IoSearch } from "react-icons/io5";
+import { User } from "../../../UserContext";
+import TeamCard from '../../../components/TeamCard/index';
+import "./index.less";
+
+interface FindTeamsTabProps {
+    data: Object[];
+    user: User;
+    compUser: any;
+    registered: Boolean;
+    fetchTeamsCallback: () => void;
+    updateRankings: () => void;
+}
+
+/**
+ * Renders the tab to view all available teams to join or leave
+ * 
+ * @param {any} data Holds the array of all teams
+ * @param {User} user 
+ * @param {any} compUser The competition user
+ * @param fetchTeamsCallback Function that refetches all team data
+ * @param updateRankings Function that retreives the new rankings of teams
+ * 
+ */
+const FindTeamsTab: React.FC<FindTeamsTabProps>= (
+    { data, user, compUser, registered, fetchTeamsCallback, updateRankings }:
+    { data: Object[], user: User, compUser: any, registered: Boolean, fetchTeamsCallback: () => void, updateRankings: () => void }
+) => {
+
+    // Constants to align the pagination options for the teams list
+    const [position] = useState<('top' | 'bottom' | 'both')>('bottom');
+    const [align] = useState<'start' | 'center' | 'end'>('center');
+
+    // Dropdown options for search bar
+    const [options, setOptions] = useState<Array<Object>>(data);
+
+    // Initialize the teams data once that data defined
+    useEffect(() => {
+        if (data) {
+            setOptions(data);
+        }
+    }, [data, registered])
+
+    const handleSearch = (value: string) => {
+        // Resets search options back to the original data if the value is an empty string
+        if (value === "") {
+            setOptions(data);
+        }
+    }
+
+    const handleSelect = (value: string) => {
+
+        // Filter the list items
+        const filteredOptions = data.filter((item: any) =>
+            item.teamName.toUpperCase().includes(value.toUpperCase())
+        );
+        setOptions(filteredOptions)
+    }
+
+    return (
+        <Content id="findTeamsContainer">
+            <AutoComplete
+                id="teamSearchBar"
+                onSearch={(text) => handleSearch(text)}
+                onSelect={handleSelect}
+
+                // list of all possible options for dropdown
+                options={options.map((item: any) => ({ value: item.teamName }))}
+
+                // filterOption to handle filtered dropdown items 
+                filterOption={(inputValue, option) =>
+                    option!.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
+                }
+                size="large"
+                style={{ width: "100%" }}
+            >
+                <Input allowClear bordered ={false} prefix={<IoSearch size = {20} id = "searchIcon" style = {{marginRight: "0.5rem", color: "lightgrey"}} />}  size="large" placeholder="Look up a team name"  />
+            </AutoComplete>
+
+            {/** List to preview all the teams based on the user's query */}
+            <List
+                split={false}
+                pagination={{ position, align, pageSize: 6 }}
+                dataSource={options}
+                renderItem={(team: any) => (
+                    <List.Item key={team.competitionName}>
+                        {<TeamCard team={team} user={user} compUser={compUser} fetchTeamCallback={fetchTeamsCallback} updateRankings={updateRankings} />}
+                    </List.Item>
+                )}
+            />
+
+        </Content>
+    );
+};
+
+export default FindTeamsTab;

--- a/src/pages/Competitions/CompetitionPortalPage/Leaderboard.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/Leaderboard.tsx
@@ -4,12 +4,14 @@ import type { ColumnsType } from "antd/es/table";
 import { CompetitionData } from "../../../actions/competition";
 import { genColor } from "../../../utils/colors";
 import "./index.less";
+import { Link } from "react-router-dom";
 
 interface LeaderBoardTabProps {
     rankData: any;
     lastRefresh: Date | null;
     updateRankingsCallback: () => void;
     isLoading: boolean;
+    competitionName: string;
 }
 const { Content } = Layout;
 
@@ -23,11 +25,12 @@ const { Content } = Layout;
  * 
  */
 const LeaderBoardTab: React.FC<LeaderBoardTabProps> = (
-    {rankData, lastRefresh, updateRankingsCallback, isLoading}:
+    {rankData, lastRefresh, updateRankingsCallback, isLoading, competitionName}:
     { rankData: any,
       lastRefresh: Date | null,
       updateRankingsCallback: () => void,
-      isLoading: boolean
+      isLoading: boolean,
+      competitionName: string
     }
 ) => {
 
@@ -85,15 +88,21 @@ const LeaderBoardTab: React.FC<LeaderBoardTabProps> = (
                     Last refreshed{': '}
                     {lastRefresh ? lastRefresh.toLocaleString() : ''}
                 </p>
-                <Button
-                    size="large"
-                    className="refresh-btn"
-                    onClick={() => {
-                        updateRankingsCallback();
-                    }}
-                >
-                    Refresh
-                </Button>
+
+                <div className="buttonContainer">
+                    {/* <Link to={{ pathname: `competitions/${competitionName}/leaderboard` }} >
+                        <Button size="large" className="full-lb-btn">Full Leaderboard</Button>
+                    </Link> */}
+                    <Button
+                        size="large"
+                        className="refresh-btn"
+                        onClick={() => {
+                            updateRankingsCallback();
+                        }}
+                    >
+                        Refresh
+                    </Button>
+                </div>
             </section>
             <Table loading={isLoading} columns={columns} dataSource={rankData} />
         </Content>

--- a/src/pages/Competitions/CompetitionPortalPage/Leaderboard.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/Leaderboard.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import { Layout, Table, Button } from 'antd';
+import type { ColumnsType } from "antd/es/table";
+import { CompetitionData } from "../../../actions/competition";
+import { genColor } from "../../../utils/colors";
+import "./index.less";
+
+interface LeaderBoardTabProps {
+    rankData: any;
+    lastRefresh: Date | null;
+    updateRankingsCallback: () => void;
+    isLoading: boolean;
+}
+const { Content } = Layout;
+
+/**
+ * Renders the leaderboard of all teams based on their ranking
+ * 
+ * @param {any} rankData The ranking data of all teams
+ * @param {Date} lastRefresh The last time when the leaderboard was refreshed
+ * @param updateRankingsCallback Function that refetches the rankings for all teams
+ * @param {boolean} isLoading Indicates if all the competitions teams info is being fetched
+ * 
+ */
+const LeaderBoardTab: React.FC<LeaderBoardTabProps> = (
+    {rankData, lastRefresh, updateRankingsCallback, isLoading}:
+    { rankData: any,
+      lastRefresh: Date | null,
+      updateRankingsCallback: () => void,
+      isLoading: boolean
+    }
+) => {
+
+    // Formats how the columns should be arranged and styled
+    const columns: ColumnsType<CompetitionData> = [
+        {
+            title: 'Rank',
+            dataIndex: 'rank',
+            sorter: (a, b) => b.score - a.score,
+            defaultSortOrder: 'ascend',
+        },
+        {
+            title: 'Team',
+            dataIndex: 'team',
+            sorter: (a, b) => a.team.length - b.team.length,
+            render(value, record, index) {
+                const color1 = genColor(record.team);
+                const color2 = genColor(`${record.team}_additional_seed`);
+
+                return (
+                    <span>
+                        <div
+                            style={{
+                                display: 'inline-block',
+                                verticalAlign: 'middle',
+                                borderRadius: '50%',
+                                width: '2rem',
+                                height: '2rem',
+                                background: `linear-gradient(30deg, ${color1}, ${color2})`,
+                                marginRight: '0.75rem',
+                            }}
+                        ></div>
+                        {value.length > 28 ? (
+                            <span>{value.substring(0, 28)}...</span>
+                        ) : (
+                            <span>{value.substring(0, 28)}</span>
+                        )}
+                    </span>
+                );
+            },
+        },
+        {
+            title: 'Score',
+            dataIndex: 'score',
+            sorter: (a, b) => a.score - b.score,
+        },
+    ];
+
+
+    return (
+        <Content id="leaderBoardContainer">
+            <section>
+
+                <p id="lastRefreshedText">
+                    Last refreshed{': '}
+                    {lastRefresh ? lastRefresh.toLocaleString() : ''}
+                </p>
+                <Button
+                    size="large"
+                    className="refresh-btn"
+                    onClick={() => {
+                        updateRankingsCallback();
+                    }}
+                >
+                    Refresh
+                </Button>
+            </section>
+            <Table loading={isLoading} columns={columns} dataSource={rankData} />
+        </Content>
+    );
+};
+
+export default LeaderBoardTab;

--- a/src/pages/Competitions/CompetitionPortalPage/SubmissionEntryCard/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/SubmissionEntryCard/index.tsx
@@ -185,7 +185,7 @@ const SubmissionEntryCard = (data: any) => {
         <p className="submissionDescription">{data.entry.description}</p>
         <span className="submissionFileRow">
           <FaLink size={20} style={{ marginRight: "1rem" }} />
-          <p>bot.targz</p>
+          <p>bot.py</p>
           {/* TODO: Add this back in when file submission works: <p>{data.entry.fileLocation}</p> */}
         </span>
       </div>

--- a/src/pages/Competitions/CompetitionPortalPage/SubmissionLogPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/SubmissionLogPage/index.tsx
@@ -107,10 +107,10 @@ function SubmissionLogPage() {
                     <h1 className="title2">Submission Log</h1>
                     <p>View your previous submissions to gauge the performance of your bots!</p>
 
-                    <span>
+                    {/* <span>
                         <Input type="search" size = "large" id = "submissionLogSearch" placeholder="search by uploader"></Input>
                         <Button id = "refreshButton" size = "large" onClick={() => fetchRecents()}><p>Refresh</p></Button>
-                    </span>
+                    </span> */}
                 </Content>
                 
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.less
+++ b/src/pages/Competitions/CompetitionPortalPage/index.less
@@ -140,7 +140,7 @@
   margin-top: 1rem;
 
   section {
-    display: inline-flex;
+    display: flex;
     width: 100%;
     justify-content: space-between;
     margin-bottom: 1rem;
@@ -150,6 +150,11 @@
       border-radius: @radius-base4;
       padding: @padding-base;
       margin-right: 2rem;
+    }
+
+    .buttonContainer {
+      display: flex;
+      gap: 0.5rem;
     }
 
     @media screen and (max-width: @sm) {
@@ -169,7 +174,6 @@
 
 #myTeamContainer {
   margin-top: 1rem;
-
   section:first-of-type {
     display: grid;
     grid-template-columns: minmax(400px, 3fr) 2fr;
@@ -189,11 +193,12 @@
 
     #leaveTeamButton {
       border: none;
+      margin-left: auto; 
     }
 
     #teamNameWrapper {
       display: flex;
-      justify-content: space-between;
+      flex-direction: row;
       align-items: center;
       width: 100%;
 
@@ -221,6 +226,7 @@
 
       h3 {
         font-weight: @semi-bold;
+        margin-bottom: 0.5rem;
       }
     }
 

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -566,7 +566,11 @@ function CompetitionPortalPage() {
         rank: 0,
         team: "",
         score: 0,
-        submitHistory: []
+        submitHistory: [],
+        scoreHistory: [],
+        winHistory: [],
+        lossHistory: [],
+        drawHistory: [],
     }
     );
 
@@ -766,6 +770,8 @@ function CompetitionPortalPage() {
             }
         })
     }
+    console.log("userrankdata", userRankData);
+    console.log("teaminfo", teamInfo);
 
 
     return (
@@ -822,7 +828,7 @@ function CompetitionPortalPage() {
                                 {compUser.competitionTeam == null ?
                                     <section id="noTeamMessage">
                                         <p>
-                                            Uh oh! You’re not in a team yet. Either make your own team or ask your friends to share their invite code,
+                                            Uh oh! You're not in a team yet. Either make your own team or ask your friends to share their invite code,
                                             then navigate to Find Teams below to join their group!
                                         </p>
                                     </section>
@@ -840,7 +846,7 @@ function CompetitionPortalPage() {
                                         {/* Values Row */}
                                         <Row gutter={16} justify="center" className="stats-row values">
                                             <Col span={6} className="stat-col">
-                                                <div className="stat-value">0</div>
+                                                <div className="stat-value">{userRankData.submitHistory.length}</div>
                                             </Col>
 
                                             <Col span={6} className="stat-col">

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -3,7 +3,7 @@ import { Row, Col, Layout, Button, Input, Modal, Upload, AutoComplete, Drawer, L
 import type { UploadProps } from 'antd';
 import TextArea from "antd/es/input/TextArea";
 
-import { InboxOutlined } from '@ant-design/icons';
+import { InboxOutlined, UploadOutlined } from '@ant-design/icons';
 import { IoHelp, IoRefresh, IoSearch, IoTime, IoEllipsisVertical, IoPersonAdd } from "react-icons/io5";
 import { FaCheck, FaClock, FaStar } from "react-icons/fa";
 
@@ -17,7 +17,6 @@ import {
     leaveTeam,
     getSubmissionDetails
 } from '../../../actions/teams/utils';
-import TeamCard from '../../../components/TeamCard/index';
 import DefaultLayout from "../../../components/layouts/default";
 import { CompetitionData, getLeaderboard, getMetaData, getRanks, registerCompetitionUser, uploadSubmission } from "../../../actions/competition";
 import { genColor } from "../../../utils/colors";
@@ -412,7 +411,21 @@ const MyTeamTab = ( { isLoadingTeamInfo, compUser, rankData, teamInfo, metaData 
                             <LineChart scoreHistory={(teamInfo != null) ? teamInfo.scoreHistory.map(Number) : []}/>
                         </div>
 
-                        <form id = "uploadFileSection">
+                        <div id = "uploadFileSection">
+                            <span id = "uploadFileHeader">
+                                <h3>Upload Submission</h3>
+                                <Tooltip title = {<p id = "submissionCountDown">{metaData.submissionsEnabled ? <CountdownTimer endDate={metaData.endDate}/> : "Submissions have closed" }</p> }>
+                                    <FaClock size = {28} />
+                                </Tooltip>
+                            </span>
+                            
+                            <Link to={{ pathname: "competitions/" + metaData.competitionName + "/upload" }} >
+                                <Button size="large" className="uploadButton" icon = {<UploadOutlined size = {14}/>}>Upload</Button>
+                            </Link>
+
+                        </div>
+
+                        {/* <form id = "uploadFileSection">
                             <span id = "uploadFileHeader">
                                 <h3>Upload Submission</h3>
                                 <Tooltip title = {<p id = "submissionCountDown">{metaData.submissionsEnabled ? <CountdownTimer endDate={metaData.endDate}/> : "Submissions have closed" }</p> }>
@@ -432,7 +445,6 @@ const MyTeamTab = ( { isLoadingTeamInfo, compUser, rankData, teamInfo, metaData 
                                 onChange={(evt) => setDesc(evt.target.value)}
                             />
 
-                            {/*Inline style needed here */}
                             <Dragger id = "uploadDragArea" style = {{borderRadius: "20px", background: "white", border: "none"}}height={150} {...uploadProps}>
                                 <p id="antUploadDragIcon">
                                     <InboxOutlined style={{color: "darkgray"}}/>
@@ -449,7 +461,8 @@ const MyTeamTab = ( { isLoadingTeamInfo, compUser, rankData, teamInfo, metaData 
                             >
                                 Submit
                             </Button>   
-                        </form>
+                        </form> 
+                        */}
 
                         <SubmissionsPreview  teamInfo={teamInfo} competitionName= {metaData.competitionName} />
                     </div>
@@ -493,13 +506,14 @@ const MyTeamTab = ( { isLoadingTeamInfo, compUser, rankData, teamInfo, metaData 
 
                         </div>
 
-                        <div id = "matchesBox">
+                        {/* <div id = "matchesBox">
                             <h3>Matches</h3>
                             <p>Check out your team's match replays to see how well youre performing!</p>
                             <Link to={`/matches/${teamInfo.teamName}`} rel="noopener noreferrer">
                                 <p style = {{color: "white", marginTop: "1rem"}}>view all &gt;</p>
                             </Link>
-                        </div>
+                        </div> */}
+
                     </div>
                     
                 </section>

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
 import { Row, Col, Layout, Button, Input, Modal, Upload, AutoComplete, Drawer, List, Skeleton, Tabs, message, Empty, Tooltip, Pagination, Table} from 'antd';
 import type { UploadProps } from 'antd';
-import { ColumnsType } from "antd/es/table";
 import TextArea from "antd/es/input/TextArea";
 
 import { InboxOutlined } from '@ant-design/icons';
@@ -28,182 +27,13 @@ import CountdownTimer from "./CountDownTimer";
 import LineChart from "./LineChart";
 import SubmissionEntryCard from "./SubmissionEntryCard";
 
+import LeaderBoardTab from "./Leaderboard";
+import FindTeamsTab from "./FindTeams";
+
 import path from 'path';
 import './index.less';
 
 const { Content } = Layout;
-
-/**
- * Renders the tab to view all available teams to join or leave
- * 
- * @param {any} data Holds the array of all teams
- * @param {User} user 
- * @param {any} compUser The competition user
- * @param fetchTeamsCallback Function that refetches all team data
- * @param updateRankings Function that retreives the new rankings of teams
- * 
- */
-const FindTeamsTab = (
-    { data, user, compUser, registered, fetchTeamsCallback, updateRankings }:
-    { data: Object[], user: User, compUser: any, registered: Boolean, fetchTeamsCallback: () => void, updateRankings: () => void }
-) => {
-
-    // Constants to align the pagination options for the teams list
-    const [position] = useState<('top' | 'bottom' | 'both')>('bottom');
-    const [align] = useState<'start' | 'center' | 'end'>('center');
-
-    // Dropdown options for search bar
-    const [options, setOptions] = useState<Array<Object>>(data);
-
-    // Initialize the teams data once that data defined
-    useEffect(() => {
-        if (data) {
-            setOptions(data);
-        }
-    }, [data, registered])
-
-    const handleSearch = (value: string) => {
-        // Resets search options back to the original data if the value is an empty string
-        if (value === "") {
-            setOptions(data);
-        }
-    }
-
-    const handleSelect = (value: string) => {
-
-        // Filter the list items
-        const filteredOptions = data.filter((item: any) =>
-            item.teamName.toUpperCase().includes(value.toUpperCase())
-        );
-        setOptions(filteredOptions)
-    }
-
-    return (
-        <Content id="findTeamsContainer">
-            <AutoComplete
-                id="teamSearchBar"
-                onSearch={(text) => handleSearch(text)}
-                onSelect={handleSelect}
-
-                // list of all possible options for dropdown
-                options={options.map((item: any) => ({ value: item.teamName }))}
-
-                // filterOption to handle filtered dropdown items 
-                filterOption={(inputValue, option) =>
-                    option!.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
-                }
-                size="large"
-                style={{ width: "100%" }}
-            >
-                <Input allowClear bordered ={false} prefix={<IoSearch size = {20} id = "searchIcon" style = {{marginRight: "0.5rem", color: "lightgrey"}} />}  size="large" placeholder="Look up a team name"  />
-            </AutoComplete>
-
-            {/** List to preview all the teams based on the user's query */}
-            <List
-                split={false}
-                pagination={{ position, align, pageSize: 6 }}
-                dataSource={options}
-                renderItem={(team: any) => (
-                    <List.Item key={team.competitionName}>
-                        {<TeamCard team={team} user={user} compUser={compUser} fetchTeamCallback={fetchTeamsCallback} updateRankings={updateRankings} />}
-                    </List.Item>
-                )}
-            />
-
-        </Content>
-    );
-};
-
-
-
-
-/**
- * Renders the leaderboard of all teams based on their ranking
- * 
- * @param {any} rankData The ranking data of all teams
- * @param {Date} lastRefresh The last time when the leaderboard was refreshed
- * @param updateRankingsCallback Function that refetches the rankings for all teams
- * @param {boolean} isLoading Indicates if all the competitions teams info is being fetched
- * 
- */
-const LeaderBoardTab = (
-    {rankData, lastRefresh, updateRankingsCallback, isLoading}:
-    { rankData: any,
-      lastRefresh: Date | null,
-      updateRankingsCallback: () => void,
-      isLoading: boolean
-    }
-) => {
-
-    // Formats how the columns should be arranged and styled
-    const columns: ColumnsType<CompetitionData> = [
-        {
-            title: 'Rank',
-            dataIndex: 'rank',
-            sorter: (a, b) => b.score - a.score,
-            defaultSortOrder: 'ascend',
-        },
-        {
-            title: 'Team',
-            dataIndex: 'team',
-            sorter: (a, b) => a.team.length - b.team.length,
-            render(value, record, index) {
-                const color1 = genColor(record.team);
-                const color2 = genColor(`${record.team}_additional_seed`);
-
-                return (
-                    <span>
-                        <div
-                            style={{
-                                display: 'inline-block',
-                                verticalAlign: 'middle',
-                                borderRadius: '50%',
-                                width: '2rem',
-                                height: '2rem',
-                                background: `linear-gradient(30deg, ${color1}, ${color2})`,
-                                marginRight: '0.75rem',
-                            }}
-                        ></div>
-                        {value.length > 28 ? (
-                            <span>{value.substring(0, 28)}...</span>
-                        ) : (
-                            <span>{value.substring(0, 28)}</span>
-                        )}
-                    </span>
-                );
-            },
-        },
-        {
-            title: 'Score',
-            dataIndex: 'score',
-            sorter: (a, b) => a.score - b.score,
-        },
-    ];
-
-
-    return (
-        <Content id="leaderBoardContainer">
-            <section>
-
-                <p id="lastRefreshedText">
-                    Last refreshed{': '}
-                    {lastRefresh ? lastRefresh.toLocaleString() : ''}
-                </p>
-                <Button
-                    size="large"
-                    className="refresh-btn"
-                    onClick={() => {
-                        updateRankingsCallback();
-                    }}
-                >
-                    Refresh
-                </Button>
-            </section>
-            <Table loading={isLoading} columns={columns} dataSource={rankData} />
-        </Content>
-    );
-};
-
 
 /**
  * Renders the submission preview list for the user's team
@@ -297,9 +127,6 @@ const SubmissionsPreview = ({teamInfo, competitionName}: {teamInfo: any, competi
     );
 }
 
-
-
-
 /**
  * Generates a unique avatar for each team member 
  * using a third party avatar library 
@@ -384,8 +211,6 @@ export const generateTeamPicture = (teamName: any) => {
 }
 
 
-
-
 /**
  * Component that displays a team's data. Contains several components 
  * to create a team, view team members, upload submissions, view submission previews, 
@@ -404,7 +229,7 @@ const MyTeamTab = ( { isLoadingTeamInfo, compUser, rankData, teamInfo, metaData 
 
     const [isLoading, setIsLoading] = useState<boolean>(false);
     
-    // Form field to create a new etam with a name
+    // Form field to create a new team with a name
     const [newTeamName, setNewTeamName] = useState<string>("");
 
     // Modal states 
@@ -540,7 +365,6 @@ const MyTeamTab = ( { isLoadingTeamInfo, compUser, rankData, teamInfo, metaData 
         createTeam(compUser.competitionName, compUser.username, newTeamName).then((res) => {
             message.success('Successfully made a new team!');
             fetchTeamsCallback();
-            console.log(compUser)
 
         })
         .catch((error) => {
@@ -557,7 +381,7 @@ const MyTeamTab = ( { isLoadingTeamInfo, compUser, rankData, teamInfo, metaData 
         :
         <Content id="myTeamContainer" >
             
-            {teamInfo !== null && teamInfo.teamName && (
+            {teamInfo !== null && teamInfo?.teamName && (
                 <section>
                     <div id="teamMainContent">
 
@@ -785,7 +609,7 @@ function CompetitionPortalPage() {
                 showModal();
             }
             else {
-                // update the compeition user state
+                // update the competition user state
                 setCompUser(res.data);
 
                 // fetch all the teams
@@ -811,11 +635,8 @@ function CompetitionPortalPage() {
 
     // Function to get ranking of user's team and all teams
     function updateRankings() {
-
         setIsLoadingLeaderBoard(true);
-
         getLeaderboard(competitionName).then((res) => {
-            console.log(res.data)
 
             let newData = res.data
                 .sort((a: any, b: any) => b.bestScore - a.bestScore) // Sort by bestScore in descending order
@@ -829,8 +650,6 @@ function CompetitionPortalPage() {
                                     score: d.bestScore,
                                     submitHistory: d.submitHistory,
                                 });
-
-                                console.log("user rank data: ", userRankData);
                             }
                         }
                         return {
@@ -905,7 +724,6 @@ function CompetitionPortalPage() {
         // If comp user is in a team, grab the team information
         if (Object.keys(compUser).length !== 0) {
             if (compUser.competitionTeam != null) {
-                console.log(compUser)
                 updateTeamInformation();
             }
             else {

--- a/src/pages/Competitions/CompetitionPortalPage/index.tsx
+++ b/src/pages/Competitions/CompetitionPortalPage/index.tsx
@@ -197,13 +197,13 @@ export const generateTeamPicture = (teamName: any) => {
     return (
         <div
             style={{
-                display: 'inline-block',
+                display: 'inline-flex',
                 verticalAlign: 'middle',
                 borderRadius: '100%',
                 width: '4rem',
                 height: '4rem',
                 background: `linear-gradient(30deg, ${color1}, ${color2})`,
-                marginRight: '0.75rem',
+                marginRight: '2rem',
             }}>
         </div>
     )
@@ -385,8 +385,10 @@ const MyTeamTab = ( { isLoadingTeamInfo, compUser, rankData, teamInfo, metaData 
                     <div id="teamMainContent">
 
                         <div id="teamHeader">
-                            {generateTeamPicture(teamInfo.teamName)}
                             <div id="teamNameWrapper">
+                                <div>
+                                    {generateTeamPicture(teamInfo.teamName)}
+                                </div>
                                 <article>
                                     <h3>{teamInfo.teamName}</h3>
                                     <p id = "rankingTag">{getOrdinal(rankData.rank)} place</p>
@@ -419,7 +421,7 @@ const MyTeamTab = ( { isLoadingTeamInfo, compUser, rankData, teamInfo, metaData 
                                 </Tooltip>
                             </span>
                             
-                            <Link to={{ pathname: "competitions/" + metaData.competitionName + "/upload" }} >
+                            <Link to={{ pathname: `competitions/${metaData.competitionName}/upload`}} >
                                 <Button size="large" className="uploadButton" icon = {<UploadOutlined size = {14}/>}>Upload</Button>
                             </Link>
 
@@ -657,24 +659,38 @@ function CompetitionPortalPage() {
         getLeaderboard(competitionName).then((res) => {
 
             let newData = res.data
-                .sort((a: any, b: any) => b.bestScore - a.bestScore) // Sort by bestScore in descending order
+                .sort((a: any, b: any) => {
+                    const latestScoreA = a.scoreHistory?.length > 0 ? a.scoreHistory[a.scoreHistory.length - 1] : -Infinity;
+                    const latestScoreB = b.scoreHistory?.length > 0 ? b.scoreHistory[b.scoreHistory.length - 1] : -Infinity;
+                    return latestScoreB - latestScoreA;
+                })
+                // .sort((a: any, b: any) => b.bestScore - a.bestScore) // Sort by bestScore in descending order
                 .map((d: any, index: number) => {
+                        const latestScore = d.scoreHistory?.length > 0 ? d.scoreHistory[d.scoreHistory.length - 1] : 0; 
 
                         if (teamInfo != null) {
                             if (d.teamName === teamInfo.teamName) {
                                 setUserRankData({
                                     rank: index + 1,
-                                    team: d.teamName,
-                                    score: d.bestScore,
+                                    team: d.teamName, 
+                                    score: latestScore,
                                     submitHistory: d.submitHistory,
+                                    scoreHistory: d.scoreHistory,
+                                    winHistory: d.winHistory,
+                                    lossHistory: d.lossHistory,
+                                    drawHistory: d.drawHistory,
                                 });
                             }
                         }
                         return {
                             rank: index + 1,
-                            team: d.teamName,
-                            score: d.bestScore,
+                            team: d.teamName, 
+                            score: latestScore,
                             submitHistory: d.submitHistory,
+                            scoreHistory: d.scoreHistory,
+                            winHistory: d.winHistory,
+                            lossHistory: d.lossHistory,
+                            drawHistory: d.drawHistory,
                         };
                 });
 
@@ -784,9 +800,6 @@ function CompetitionPortalPage() {
             }
         })
     }
-    console.log("userrankdata", userRankData);
-    console.log("teaminfo", teamInfo);
-
 
     return (
         <DefaultLayout>
@@ -864,7 +877,12 @@ function CompetitionPortalPage() {
                                             </Col>
 
                                             <Col span={6} className="stat-col">
-                                                <div className="stat-value">{userRankData.score}</div>
+                                                <div className="stat-value"> 
+                                                    {userRankData.scoreHistory?.length > 0
+                                                        ? userRankData.scoreHistory[userRankData.scoreHistory?.length - 1]
+                                                        : 0
+                                                    }
+                                                </div>
                                             </Col>
 
                                             <Col span={6} className="stat-col">
@@ -872,7 +890,20 @@ function CompetitionPortalPage() {
                                             </Col>
 
                                             <Col span={6} className="stat-col">
-                                                <div className="stat-value">0-0-0</div>
+                                                <div className="stat-value">
+                                                {userRankData.winHistory?.length > 0
+                                                    ? userRankData.winHistory[userRankData.winHistory?.length - 1]
+                                                    : 0
+                                                }-
+                                                {userRankData.drawHistory?.length > 0
+                                                    ? userRankData.drawHistory[userRankData.drawHistory?.length - 1]
+                                                    : 0
+                                                }-
+                                                {userRankData.lossHistory?.length > 0
+                                                    ? userRankData.lossHistory[userRankData.lossHistory?.length - 1]
+                                                    : 0
+                                                }
+                                                </div>
                                             </Col>
                                         </Row>
                                     </section>
@@ -903,7 +934,8 @@ function CompetitionPortalPage() {
                                         rankData={rankingsData}
                                         lastRefresh={lastRefresh}
                                         updateRankingsCallback={updateRankings}
-                                        isLoading={isLoadingLeaderBoard} />
+                                        isLoading={isLoadingLeaderBoard} 
+                                        competitionName={competitionName}/>
                                 },
                                 {
                                     label: <p>Find Teams</p>,

--- a/src/pages/Competitions/CompetitionUploadPage/index.tsx
+++ b/src/pages/Competitions/CompetitionUploadPage/index.tsx
@@ -83,7 +83,7 @@ const CompetitionUploadPage = () => {
     )
       .then((res) => {
         message.success('Submission Uploaded Succesfully');
-        history.replace(path.join('/competitions', competitionID));
+        history.replace('/portal');
       })
       .catch((err) => {
         console.log(err);
@@ -109,12 +109,12 @@ const CompetitionUploadPage = () => {
   };
 
   const beforeUpload = (file: any) => {
-    const isPythonFile = file.name.endsWith('.py');
-    if (!isPythonFile) {
-      message.error('You can only upload Python (.py) files!');
+    const isBotPy = file.name === 'bot.py';
+    if (!isBotPy) {
+      message.error('You can only upload a file named bot.py!');
     }
 
-    return isPythonFile;
+    return isBotPy;
   };
 
   return (
@@ -124,7 +124,7 @@ const CompetitionUploadPage = () => {
         <BackLink to="../" />
         <h2>Submission to {competitionID}</h2>
         <p>
-          You must submit a .py file that contains your submission. You can
+          You must submit a bot.py file that contains your submission. You can
           add an optional description below as well as tags.
         </p>
         <br />


### PR DESCRIPTION
- FEATURE: new admin portal page for uploading results (uploading is currently bugged :/)
- FEATURE: win/draw/loss history now exists and works. so does latest score
- FIX: ?help broke team names so they're encoded
- FIX: bot.targz now hardcoded renamed to bot.py :skull: someone should fix this eventually
- FIX: hide matches box for now since not being used
- FIX: upload section now links to upload page so we only have to deal with one. this can be put back later
- RESTRUCTURE: findteams and leaderboard have been pulled on to their own components bc they are large. myteams also should move out but given time constraint, don't break for now
- RESTRUCTURE: sort by latest score on leaderboard