### PR TITLE
fix: prevent broken social links on alumni page

### DIFF
--- a/src/pages/AlumniPage/alumni.ts
+++ b/src/pages/AlumniPage/alumni.ts
@@ -105,8 +105,16 @@ const fetchData = async (): Promise<Record<string, Person[]>>=> {
             picture: picture?.startsWith("https://cdn.discordapp.com/") ? 
                 "/logo512.png" : picture || "/logo512.png", 
             socials: {
-              github: github ? (`https://github.com/${github}`) : '',
-              linkedin: linkedin || '',
+              github: github ? (github.includes('https://')
+                  ? github
+                  : github.includes("github.com")
+                  ? (`https://${github}`)
+                  : (`https://github.com/${github}`))
+                  : '',
+              linkedin: linkedin ? (linkedin.includes('https://')
+                  ? linkedin 
+                  : (`https://${linkedin}`))
+                  : '',
               website: website || '',
             }
           }


### PR DESCRIPTION
- changed handling of linkedin and github links on board spreadsheet to prevent broken links on alumni page